### PR TITLE
feat: add centralized dev-dependencies Composer package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Exclude CI-only files from Composer installs (export-ignore).
+# Only config/, Makefile.include, and composer.json are needed by consumers.
+/.gitattributes    export-ignore
+/.github/          export-ignore
+/docs/             export-ignore
+/scripts/          export-ignore
+/README.md         export-ignore

--- a/Makefile.include
+++ b/Makefile.include
@@ -1,0 +1,93 @@
+# Shared Makefile targets for Netresearch TYPO3 extensions.
+#
+# Include in your extension's Makefile:
+#
+#   -include .Build/vendor/netresearch/typo3-ci-workflows/Makefile.include
+#
+#   # Add extension-specific targets below (ddev, docs, etc.)
+#
+# The `-include` prefix suppresses errors if the file doesn't exist yet
+# (e.g., before the first `composer install`).
+
+.PHONY: help
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+# ===================================
+# Composer
+# ===================================
+
+.PHONY: install
+install: ## Install composer dependencies
+	composer install
+
+.PHONY: update
+update: ## Update composer dependencies
+	composer update
+
+# ===================================
+# Code Quality
+# ===================================
+
+.PHONY: cgl
+cgl: ## Check code style (dry-run)
+	composer ci:test:php:cgl
+
+.PHONY: cgl-fix
+cgl-fix: ## Fix code style
+	composer ci:cgl
+
+.PHONY: phpstan
+phpstan: ## Run PHPStan static analysis
+	composer ci:test:php:phpstan
+
+.PHONY: phpstan-baseline
+phpstan-baseline: ## Regenerate PHPStan baseline
+	composer ci:test:php:phpstan:baseline
+
+.PHONY: rector
+rector: ## Run Rector dry-run
+	composer ci:test:php:rector
+
+.PHONY: rector-fix
+rector-fix: ## Apply Rector changes
+	composer ci:rector
+
+.PHONY: lint
+lint: ## Run PHP syntax check
+	composer ci:test:php:lint
+
+.PHONY: quality
+quality: lint phpstan cgl rector ## Run all quality checks
+
+# ===================================
+# Tests
+# ===================================
+
+.PHONY: test
+test: test-unit test-functional ## Run all tests (unit + functional)
+
+.PHONY: test-unit
+test-unit: ## Run unit tests
+	composer ci:test:php:unit
+
+.PHONY: test-functional
+test-functional: ## Run functional tests
+	composer ci:test:php:functional
+
+# ===================================
+# CI (quality + tests)
+# ===================================
+
+.PHONY: ci
+ci: quality test ## Run complete CI pipeline
+
+# ===================================
+# Cleanup
+# ===================================
+
+.PHONY: clean
+clean: ## Clean temporary files and caches
+	rm -rf .php-cs-fixer.cache .Build/.php-cs-fixer.cache .phplint.cache .phpunit.result.cache var/
+
+.DEFAULT_GOAL := help

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "netresearch/typo3-ci-workflows",
+    "description": "Centralized dev-dependencies, configs, and CI tooling for Netresearch TYPO3 extensions",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "a9f/typo3-fractor": "^0.5",
+        "captainhook/captainhook": "^5.28",
+        "captainhook/hook-installer": "^1.0",
+        "friendsofphp/php-cs-fixer": "^3.65",
+        "infection/infection": "^0.29 || ^0.30 || ^0.31 || ^0.32",
+        "nikic/php-fuzzer": "^0.0.11",
+        "overtrue/phplint": "^9.5",
+        "php": "^8.2",
+        "phpat/phpat": "^0.12",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "rector/rector": "^2.0",
+        "saschaegerer/phpstan-typo3": "^2.0 || ^3.0",
+        "ssch/typo3-rector": "^3.0",
+        "typo3/testing-framework": "^8.0 || ^9.0"
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "a9f/fractor-extension-installer": true,
+            "captainhook/hook-installer": true,
+            "infection/extension-installer": true,
+            "phpstan/extension-installer": true,
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
+        }
+    }
+}

--- a/config/captainhook/captainhook.json
+++ b/config/captainhook/captainhook.json
@@ -10,7 +10,7 @@
             {
                 "action": "\\CaptainHook\\App\\Hook\\Message\\Action\\Regex",
                 "options": {
-                    "regex": "#^(feat|fix|chore|docs|test|refactor|style|ci|perf|build|revert)(\\(.+\\))?: .{1,72}$#"
+                    "regex": "#^(feat|fix|chore|docs|test|refactor|style|ci|perf|build|revert)(\\([^)]+\\))?!?: .{1,72}$#"
                 }
             }
         ]

--- a/config/captainhook/captainhook.json
+++ b/config/captainhook/captainhook.json
@@ -1,0 +1,64 @@
+{
+    "config": {
+        "verbosity": "normal",
+        "fail-on-first-error": true,
+        "ansi-colors": true
+    },
+    "commit-msg": {
+        "enabled": true,
+        "actions": [
+            {
+                "action": "\\CaptainHook\\App\\Hook\\Message\\Action\\Regex",
+                "options": {
+                    "regex": "#^(feat|fix|chore|docs|test|refactor|style|ci|perf|build|revert)(\\(.+\\))?: .{1,72}$#"
+                }
+            }
+        ]
+    },
+    "pre-commit": {
+        "enabled": true,
+        "actions": [
+            {
+                "action": "composer ci:test:php:lint",
+                "conditions": []
+            },
+            {
+                "action": "composer ci:test:php:cgl",
+                "conditions": []
+            },
+            {
+                "action": "composer ci:test:php:phpstan",
+                "conditions": []
+            }
+        ]
+    },
+    "pre-push": {
+        "enabled": true,
+        "actions": [
+            {
+                "action": "composer ci:test:php:unit",
+                "conditions": []
+            }
+        ]
+    },
+    "prepare-commit-msg": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-merge": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-checkout": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-rewrite": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-change": {
+        "enabled": false,
+        "actions": []
+    }
+}

--- a/config/php-cs-fixer/rules.php
+++ b/config/php-cs-fixer/rules.php
@@ -41,9 +41,9 @@
  */
 
 return [
-    // Base rulesets — PER-CS 2.0 + Symfony as foundation
+    // Base rulesets — PER-CS 3.0 + Symfony as foundation
     '@Symfony'         => true,
-    '@PER-CS2x0'       => true,
+    '@PER-CS3x0'       => true,
     '@PHP8x2Migration' => true,
 
     // Strict typing

--- a/config/php-cs-fixer/rules.php
+++ b/config/php-cs-fixer/rules.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Shared PHP-CS-Fixer rules for Netresearch TYPO3 extensions.
+ *
+ * Usage in your extension's Build/.php-cs-fixer.dist.php:
+ *
+ *   $sharedRules = require __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/php-cs-fixer/rules.php';
+ *
+ *   $header = <<<EOF
+ *   Copyright (c) 2025-2026 Netresearch DTT GmbH
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *   EOF;
+ *
+ *   $finder = PhpCsFixer\Finder::create()
+ *       ->in(__DIR__ . '/..')
+ *       ->exclude(['.Build', 'config', 'node_modules', 'var'])
+ *       ->notPath('ext_emconf.php');
+ *
+ *   $config = (new PhpCsFixer\Config())
+ *       ->setRiskyAllowed(true)
+ *       ->setRules(array_merge($sharedRules, [
+ *           'header_comment' => [
+ *               'header'       => $header,
+ *               'comment_type' => 'comment',
+ *               'location'     => 'after_open',
+ *               'separate'     => 'both',
+ *           ],
+ *       ]))
+ *       ->setFinder($finder);
+ *
+ *   // Allow running on newer PHP than composer.json minimum
+ *   if (method_exists($config, 'setUnsupportedPhpVersionAllowed')) {
+ *       $config->setUnsupportedPhpVersionAllowed(true);
+ *   }
+ *
+ *   return $config;
+ *
+ * Note: Extensions must add 'captainhook/hook-installer', 'phpstan/extension-installer',
+ * and 'a9f/fractor-extension-installer' to their allow-plugins in composer.json.
+ */
+
+return [
+    // Base rulesets — PER-CS 2.0 + Symfony as foundation
+    '@Symfony'         => true,
+    '@PER-CS2x0'       => true,
+    '@PHP82Migration'  => true,
+
+    // Strict typing
+    'declare_strict_types' => true,
+
+    // Spacing
+    'concat_space' => ['spacing' => 'one'],
+
+    // Docblocks — keep stable behavior
+    'phpdoc_to_comment'          => false,
+    'no_superfluous_phpdoc_tags' => false,
+    'phpdoc_separation'          => [
+        'groups' => [['author', 'license', 'link']],
+    ],
+
+    // Aliases
+    'no_alias_functions' => true,
+
+    // Alignment
+    'binary_operator_spaces' => [
+        'operators' => [
+            '='  => 'align_single_space_minimal',
+            '=>' => 'align_single_space_minimal',
+        ],
+    ],
+
+    // No Yoda
+    'yoda_style' => [
+        'equal'                => false,
+        'identical'            => false,
+        'less_and_greater'     => false,
+        'always_move_variable' => false,
+    ],
+
+    // Imports
+    'global_namespace_import' => [
+        'import_classes'   => true,
+        'import_constants' => true,
+        'import_functions' => true,
+    ],
+    'no_unused_imports' => true,
+    'ordered_imports'   => ['sort_algorithm' => 'alpha'],
+
+    // Function declarations
+    'function_declaration' => [
+        'closure_function_spacing' => 'one',
+        'closure_fn_spacing'       => 'one',
+    ],
+
+    // Modern syntax
+    'trailing_comma_in_multiline' => [
+        'elements' => ['arrays', 'arguments', 'parameters'],
+    ],
+
+    // Whitespace
+    'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+
+    // Style preferences
+    'single_line_throw' => false,
+    'self_accessor'     => false,
+];

--- a/config/php-cs-fixer/rules.php
+++ b/config/php-cs-fixer/rules.php
@@ -44,7 +44,7 @@ return [
     // Base rulesets — PER-CS 2.0 + Symfony as foundation
     '@Symfony'         => true,
     '@PER-CS2x0'       => true,
-    '@PHP82Migration'  => true,
+    '@PHP8x2Migration' => true,
 
     // Strict typing
     'declare_strict_types' => true,

--- a/config/phpstan/phpstan.neon
+++ b/config/phpstan/phpstan.neon
@@ -1,0 +1,35 @@
+# Shared PHPStan parameters for Netresearch TYPO3 extensions.
+#
+# phpstan/extension-installer (included in this package) auto-registers
+# phpstan-strict-rules, phpstan-deprecation-rules, phpstan-phpunit,
+# phpstan-typo3, and phpat — no manual neon includes needed for those.
+#
+# IMPORTANT: If your extension previously did NOT use saschaegerer/phpstan-typo3,
+# adding this package will change PHPStan's type inference for TYPO3 APIs
+# (e.g. GeneralUtility::makeInstance() returns proper types instead of mixed).
+# You will need to regenerate your phpstan-baseline.neon after migration.
+#
+# Extensions include this file in their own phpstan.neon:
+#
+#   includes:
+#       - %currentWorkingDirectory%/.Build/vendor/netresearch/typo3-ci-workflows/config/phpstan/phpstan.neon
+#       - phpstan-baseline.neon
+#   parameters:
+#       paths:
+#           - %currentWorkingDirectory%/Classes/
+#       excludePaths:
+#           - %currentWorkingDirectory%/.Build/*
+#
+# MIGRATION: Remove any manual includes for phpstan-strict-rules, phpstan-deprecation-rules,
+# phpstan-phpunit, or phpstan-typo3 neon files — extension-installer handles these.
+#
+# Override `level` in your extension's phpstan.neon if level 10 is too strict.
+
+parameters:
+    level: 10
+
+    treatPhpDocTypesAsCertain: false
+    inferPrivatePropertyTypeFromConstructor: true
+    checkMissingCallableSignature: true
+    checkUninitializedProperties: true
+    reportUnmatchedIgnoredErrors: true

--- a/config/rector/rector.php
+++ b/config/rector/rector.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Shared Rector base configuration for Netresearch TYPO3 extensions.
+ *
+ * This config provides common code-quality sets and rule skips.
+ * Rector's sets() and skip() are additive — extensions can safely call them
+ * again to add PHP-level, TYPO3-level, and extension-specific entries.
+ *
+ * Usage in your extension's Build/rector.php:
+ *
+ *   declare(strict_types=1);
+ *
+ *   use Rector\Config\RectorConfig;
+ *   use Rector\Set\ValueObject\LevelSetList;
+ *   use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
+ *
+ *   $configure = require __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
+ *
+ *   return static function (RectorConfig $rectorConfig) use ($configure): void {
+ *       // Apply shared base config (sets + skips are additive)
+ *       $configure($rectorConfig);
+ *
+ *       // Extension-specific paths
+ *       $rectorConfig->paths([
+ *           __DIR__ . '/../Classes',
+ *           __DIR__ . '/../Configuration',
+ *           __DIR__ . '/../Tests',
+ *       ]);
+ *
+ *       // Extension-specific skips (merged with shared skips)
+ *       $rectorConfig->skip([
+ *           __DIR__ . '/../.Build',
+ *           __DIR__ . '/../ext_emconf.php',
+ *       ]);
+ *
+ *       $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
+ *       $rectorConfig->phpVersion(80200);
+ *
+ *       // PHP and TYPO3 level sets — adjust to your extension's requirements
+ *       $rectorConfig->sets([
+ *           LevelSetList::UP_TO_PHP_82,          // Match your composer.json php constraint
+ *           Typo3LevelSetList::UP_TO_TYPO3_13,   // Use lowest supported TYPO3 major
+ *       ]);
+ *   };
+ */
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->importNames();
+    $rectorConfig->removeUnusedImports();
+
+    // Common code-quality rule sets
+    $rectorConfig->sets([
+        SetList::CODE_QUALITY,
+        SetList::CODING_STYLE,
+        SetList::DEAD_CODE,
+        SetList::EARLY_RETURN,
+        SetList::INSTANCEOF,
+        SetList::PRIVATIZATION,
+        SetList::TYPE_DECLARATION,
+    ]);
+
+    // Common skips — rules that cause issues across TYPO3 extensions
+    $rectorConfig->skip([
+        // Rename catch variables to match exception type — too noisy
+        CatchExceptionNameMatchingTypeRector::class,
+
+        // Constructor promotion conflicts with TYPO3 DI patterns
+        ClassPropertyAssignToConstructorPromotionRector::class,
+
+        // Keep explicit PHPDoc tags for documentation clarity
+        RemoveUselessParamTagRector::class,
+        RemoveUselessReturnTagRector::class,
+        RemoveUselessVarTagRector::class,
+
+        // Removing private method params can break internal API contracts
+        RemoveUnusedPrivateMethodParameterRector::class,
+    ]);
+};


### PR DESCRIPTION
## Summary

- Adds `composer.json` to make this repo a dual-purpose package (reusable CI workflows + Composer library)
- 18 shared dev-dependencies (17 packages + PHP platform requirement) in `require` (installed transitively when extensions add this to `require-dev`)
- Shared config files for PHPStan, PHP-CS-Fixer, Rector, CaptainHook
- Shared Makefile targets via `Makefile.include`
- `.gitattributes` to exclude CI-only files from Composer installs

## What's included

| File | Purpose |
|------|---------|
| `composer.json` | Package with 19 shared dev-deps (`php: ^8.2`) |
| `config/phpstan/phpstan.neon` | Shared PHPStan params (level 10, strict) |
| `config/php-cs-fixer/rules.php` | Shared rules array (extensions `array_merge`) |
| `config/rector/rector.php` | Shared base config closure (additive sets/skips) |
| `config/captainhook/captainhook.json` | Pre-commit hooks (conventional commits, lint/cgl/phpstan) |
| `Makefile.include` | 16 standard targets (quality, test, ci, clean, etc.) |
| `.gitattributes` | Excludes `.github/`, `docs/`, `scripts/`, `README.md` from Composer |

## How extensions consume this

**Before** (e.g., rte_ckeditor_image — 11 entries):
```json
"require-dev": {
    "typo3/testing-framework": "^8.0 || ^9.0",
    "friendsofphp/php-cs-fixer": "^3.87",
    "phpstan/phpstan": "^2.0",
    "phpstan/phpstan-strict-rules": "^2.0",
    ...
}
```

**After** (2 entries):
```json
"require-dev": {
    "netresearch/typo3-ci-workflows": "^1.0",
    "bk2k/bootstrap-package": "^15.0 || ^16.0"
}
```

## Review notes

- 5 review cycles performed (code review, security audit, dependency resolution testing, usability/integration review, final comprehensive)
- Tested Composer resolution with both TYPO3 13 and TYPO3 14 — both resolve successfully
- Confirmed Rector `skip()`/`sets()` are additive via source code inspection
- Confirmed CaptainHook hook-installer skips in CI (`CI=true`)
- Confirmed PHPStan extension-installer auto-registers all extensions

## Test plan

- [ ] `composer validate --strict` passes
- [ ] Dependency resolution works (simulated with TYPO3 13 and 14)
- [ ] PHP syntax check passes for all `.php` config files
- [ ] JSON validation passes for `composer.json` and `captainhook.json`
- [ ] Makefile targets render correctly
- [ ] After merge: tag v1.0.0, register on Packagist
- [ ] Pilot migration: t3x-rte_ckeditor_image
