### PR TITLE
feat: add extension lint checks for TER compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,29 @@ jobs:
             find . -name '*.php' -not -path './.Build/*' -not -path './vendor/*' -print0 | xargs -0 -P"$(nproc)" -n1 php -l
           fi
 
+      - name: Check ext_emconf.php for strict_types
+        run: |
+          if [[ -f ext_emconf.php ]]; then
+            if grep -q 'declare(strict_types=1)' ext_emconf.php; then
+              echo "::error file=ext_emconf.php::ext_emconf.php must NOT contain declare(strict_types=1) — TER cannot parse it with strict_types enabled. Remove the declaration from this file."
+              exit 1
+            else
+              echo "ext_emconf.php: OK (no strict_types declaration)"
+            fi
+          else
+            echo "No ext_emconf.php found — skipping check"
+          fi
+
+      - name: Check .gitattributes for export-ignore
+        run: |
+          if [[ ! -f .gitattributes ]]; then
+            echo "::warning::.gitattributes file is missing. For TER publishing, add .gitattributes with export-ignore rules to exclude dev files (tests, CI configs) from the release archive."
+          elif ! grep -q 'export-ignore' .gitattributes; then
+            echo "::warning::.gitattributes exists but contains no export-ignore rules. Add export-ignore entries for dev files (tests, CI configs) to keep TER release archives clean."
+          else
+            echo ".gitattributes: OK (has export-ignore rules)"
+          fi
+
   # CGL runs on first PHP version only - code style results are PHP-version-independent
   cgl:
     name: Code Style


### PR DESCRIPTION
## Summary

- **ext_emconf.php strict_types check** (hard failure): TER cannot parse `ext_emconf.php` when it contains `declare(strict_types=1)`. The shared PHP-CS-Fixer config already excludes this file, but extensions not using the shared config can still break TER uploads. This check catches the issue early in CI.
- **.gitattributes export-ignore check** (warning only): Extensions published to TER should have `.gitattributes` with `export-ignore` rules to prevent `tailor ter:publish` from uploading dev files (tests, CI configs, etc.). This emits a warning annotation — it does not fail the build.

Both checks run as part of the existing Lint job, requiring no additional dependencies or setup.

## Test plan

- [ ] Verify CI passes on this PR (the workflow itself has no ext_emconf.php, so the strict_types check skips gracefully)
- [ ] Test with an extension repo that has `declare(strict_types=1)` in ext_emconf.php — should fail
- [ ] Test with an extension repo missing `.gitattributes` — should emit a warning annotation
- [ ] Test with an extension repo having `.gitattributes` without `export-ignore` — should emit a warning annotation
- [ ] Test with a properly configured extension — both checks should pass silently