### PR TITLE
fix: address PR #10 review feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         if: ${{ matrix.php == fromJSON(inputs.php-versions)[0] }}
         run: |
           if [[ -f ext_emconf.php ]]; then
-            if grep -Eq '^\s*declare\s*\(\s*strict_types\s*=\s*1\s*\)\s*;?' ext_emconf.php; then
+            if grep -Eq '^[[:space:]]*declare[[:space:]]*\([[:space:]]*strict_types[[:space:]]*=[[:space:]]*1[[:space:]]*\)[[:space:]]*;?' ext_emconf.php; then
               echo "::error file=ext_emconf.php::ext_emconf.php must NOT contain declare(strict_types=1) — TER cannot parse it with strict_types enabled. Remove the declaration from this file."
               exit 1
             else
@@ -166,7 +166,7 @@ jobs:
         run: |
           if [[ ! -f .gitattributes ]]; then
             echo "::warning::.gitattributes file is missing. For TER publishing, add .gitattributes with export-ignore rules to exclude dev files (tests, CI configs) from the release archive."
-          elif ! grep -vE '^\s*#' .gitattributes | grep -q 'export-ignore'; then
+          elif ! grep -Ev '^[[:space:]]*#|^[[:space:]]*$' .gitattributes | grep -q 'export-ignore'; then
             echo "::warning::.gitattributes exists but contains no export-ignore rules. Add export-ignore entries for dev files (tests, CI configs) to keep TER release archives clean."
           else
             echo ".gitattributes: OK (has export-ignore rules)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,9 +148,10 @@ jobs:
           fi
 
       - name: Check ext_emconf.php for strict_types
+        if: ${{ matrix.php == fromJSON(inputs.php-versions)[0] }}
         run: |
           if [[ -f ext_emconf.php ]]; then
-            if grep -q 'declare(strict_types=1)' ext_emconf.php; then
+            if grep -Eq '^\s*declare\s*\(\s*strict_types\s*=\s*1\s*\)\s*;?' ext_emconf.php; then
               echo "::error file=ext_emconf.php::ext_emconf.php must NOT contain declare(strict_types=1) — TER cannot parse it with strict_types enabled. Remove the declaration from this file."
               exit 1
             else
@@ -161,10 +162,11 @@ jobs:
           fi
 
       - name: Check .gitattributes for export-ignore
+        if: ${{ matrix.php == fromJSON(inputs.php-versions)[0] }}
         run: |
           if [[ ! -f .gitattributes ]]; then
             echo "::warning::.gitattributes file is missing. For TER publishing, add .gitattributes with export-ignore rules to exclude dev files (tests, CI configs) from the release archive."
-          elif ! grep -q 'export-ignore' .gitattributes; then
+          elif ! grep -vE '^\s*#' .gitattributes | grep -q 'export-ignore'; then
             echo "::warning::.gitattributes exists but contains no export-ignore rules. Add export-ignore entries for dev files (tests, CI configs) to keep TER release archives clean."
           else
             echo ".gitattributes: OK (has export-ignore rules)"


### PR DESCRIPTION
## Summary
Addresses the three review comments from [PR #10](https://github.com/netresearch/typo3-ci-workflows/pull/10):

- **Whitespace-tolerant strict_types regex**: `declare(strict_types=1)` check now uses `-Eq '^\s*declare\s*\(\s*strict_types\s*=\s*1\s*\)\s*;?'` to catch variants with whitespace
- **Filter comments in .gitattributes check**: Uses `grep -vE '^\s*#'` to exclude comment lines before checking for `export-ignore`
- **Run TER checks once**: Added `if: matrix.php == fromJSON(inputs.php-versions)[0]` condition so ext_emconf.php and .gitattributes checks run only on the first PHP version, avoiding duplicate warnings

## Test plan
- [ ] Self-CI passes (actionlint validates the workflow syntax)
- [ ] Verify TER checks appear once in lint matrix, not per PHP version