### PR TITLE
docs: add security warning about secrets: inherit

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,3 +828,21 @@ composer install
 - No `${{ }}` expression interpolation in `run:` blocks
 - Randomized heredoc delimiters to prevent output injection
 - Timeout-minutes on every job
+
+### Secret Propagation
+
+**Never use `secrets: inherit`** when calling these workflows. Always pass only the specific secrets each workflow needs:
+
+```yaml
+# Good - explicit secrets
+secrets:
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+# Bad - exposes ALL org secrets to every action in the workflow chain
+secrets: inherit
+```
+
+Using `secrets: inherit` is a supply chain risk. If any third-party action in the
+workflow chain is compromised (cf. [netresearch/ofelia#535](https://github.com/netresearch/ofelia/issues/535)),
+the attacker gains access to **all** organization secrets. Passing secrets explicitly
+limits the blast radius to only the secrets that workflow actually needs.

--- a/README.md
+++ b/README.md
@@ -838,11 +838,12 @@ composer install
 secrets:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-# Bad - exposes ALL org secrets to every action in the workflow chain
+# Bad - exposes all secrets accessible to the caller to every action in the chain
 secrets: inherit
 ```
 
 Using `secrets: inherit` is a supply chain risk. If any third-party action in the
 workflow chain is compromised (cf. [netresearch/ofelia#535](https://github.com/netresearch/ofelia/issues/535)),
-the attacker gains access to **all** organization secrets. Passing secrets explicitly
-limits the blast radius to only the secrets that workflow actually needs.
+the attacker gains access to every secret the calling workflow can access. Passing
+secrets explicitly limits the blast radius to only what the workflow actually needs.
+See the [GitHub documentation on passing secrets](https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-secrets-to-a-reusable-workflow).


### PR DESCRIPTION
## Summary

- Adds a "Secret Propagation" subsection under the existing Security section in README.md
- Warns callers to never use `secrets: inherit` and always pass secrets explicitly
- References [netresearch/ofelia#535](https://github.com/netresearch/ofelia/issues/535) as a real-world example of supply chain risk

## Rationale

If any third-party action in the reusable workflow chain is compromised, `secrets: inherit` exposes **all** organization secrets to the attacker. Explicit secret passing limits the blast radius to only the secrets that workflow actually needs.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] No functional changes — documentation only