### PR TITLE
fix: inline render-guides docker steps to avoid unpinned composite action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,11 +43,25 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Render Documentation
-        uses: typo3-documentation/render-guides@7b3323156fccf762a2689cd38dfa6910015a7033 # 0.37.0
+      - name: Configure Documentation
+        uses: docker://ghcr.io/typo3-documentation/render-guides@sha256:431ac2644f0230c5e22174ec9d5f95c2271b038193765c3851bfdc2ad9e8cde5 # latest
+        env:
+          SHELL_VERBOSITY: '3'
         with:
-          input: ${{ inputs.input }}
-          output: ${{ inputs.output }}
+          args: >-
+            configure
+            ${{ inputs.input }}
+
+      - name: Render Documentation
+        uses: docker://ghcr.io/typo3-documentation/render-guides@sha256:431ac2644f0230c5e22174ec9d5f95c2271b038193765c3851bfdc2ad9e8cde5 # latest
+        env:
+          SHELL_VERBOSITY: '3'
+        with:
+          args: >-
+            render
+            --config=${{ inputs.input }}
+            --output=${{ inputs.output }}
+            ${{ inputs.input }}
 
       - name: Check for Warnings
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,24 +44,25 @@ jobs:
           persist-credentials: false
 
       - name: Configure Documentation
-        uses: docker://ghcr.io/typo3-documentation/render-guides@sha256:431ac2644f0230c5e22174ec9d5f95c2271b038193765c3851bfdc2ad9e8cde5 # latest
         env:
+          DOCS_IMAGE: ghcr.io/typo3-documentation/render-guides@sha256:431ac2644f0230c5e22174ec9d5f95c2271b038193765c3851bfdc2ad9e8cde5
           SHELL_VERBOSITY: '3'
-        with:
-          args: >-
-            configure
-            ${{ inputs.input }}
+          INPUT_PATH: ${{ inputs.input }}
+        run: |
+          docker run --rm -v "${GITHUB_WORKSPACE}:/project" -w /project \
+            -e SHELL_VERBOSITY="${SHELL_VERBOSITY}" \
+            "${DOCS_IMAGE}" configure "${INPUT_PATH}"
 
       - name: Render Documentation
-        uses: docker://ghcr.io/typo3-documentation/render-guides@sha256:431ac2644f0230c5e22174ec9d5f95c2271b038193765c3851bfdc2ad9e8cde5 # latest
         env:
+          DOCS_IMAGE: ghcr.io/typo3-documentation/render-guides@sha256:431ac2644f0230c5e22174ec9d5f95c2271b038193765c3851bfdc2ad9e8cde5
           SHELL_VERBOSITY: '3'
-        with:
-          args: >-
-            render
-            --config=${{ inputs.input }}
-            --output=${{ inputs.output }}
-            ${{ inputs.input }}
+          INPUT_PATH: ${{ inputs.input }}
+          OUTPUT_PATH: ${{ inputs.output }}
+        run: |
+          docker run --rm -v "${GITHUB_WORKSPACE}:/project" -w /project \
+            -e SHELL_VERBOSITY="${SHELL_VERBOSITY}" \
+            "${DOCS_IMAGE}" render --config="${INPUT_PATH}" --output="${OUTPUT_PATH}" "${INPUT_PATH}"
 
       - name: Check for Warnings
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,10 @@ on:
 
 permissions: {}
 
+env:
+  # typo3-documentation/render-guides 0.37.0
+  RENDER_GUIDES_IMAGE: ghcr.io/typo3-documentation/render-guides@sha256:431ac2644f0230c5e22174ec9d5f95c2271b038193765c3851bfdc2ad9e8cde5
+
 jobs:
   render:
     name: Render Documentation
@@ -45,24 +49,22 @@ jobs:
 
       - name: Configure Documentation
         env:
-          DOCS_IMAGE: ghcr.io/typo3-documentation/render-guides@sha256:431ac2644f0230c5e22174ec9d5f95c2271b038193765c3851bfdc2ad9e8cde5
           SHELL_VERBOSITY: '3'
           INPUT_PATH: ${{ inputs.input }}
         run: |
           docker run --rm -v "${GITHUB_WORKSPACE}:/project" -w /project \
             -e SHELL_VERBOSITY="${SHELL_VERBOSITY}" \
-            "${DOCS_IMAGE}" configure "${INPUT_PATH}"
+            "${RENDER_GUIDES_IMAGE}" configure "${INPUT_PATH}"
 
       - name: Render Documentation
         env:
-          DOCS_IMAGE: ghcr.io/typo3-documentation/render-guides@sha256:431ac2644f0230c5e22174ec9d5f95c2271b038193765c3851bfdc2ad9e8cde5
           SHELL_VERBOSITY: '3'
           INPUT_PATH: ${{ inputs.input }}
           OUTPUT_PATH: ${{ inputs.output }}
         run: |
           docker run --rm -v "${GITHUB_WORKSPACE}:/project" -w /project \
             -e SHELL_VERBOSITY="${SHELL_VERBOSITY}" \
-            "${DOCS_IMAGE}" render --config="${INPUT_PATH}" --output="${OUTPUT_PATH}" "${INPUT_PATH}"
+            "${RENDER_GUIDES_IMAGE}" render --config="${INPUT_PATH}" --output="${OUTPUT_PATH}" "${INPUT_PATH}"
 
       - name: Check for Warnings
         env:

--- a/.github/workflows/self-ci.yml
+++ b/.github/workflows/self-ci.yml
@@ -219,6 +219,9 @@ jobs:
               # Skip self-references to this repo's reusable workflows
               [[ "$ref" == netresearch/typo3-ci-workflows/* ]] && continue
 
+              # Skip docker:// references pinned by digest (@sha256:...)
+              [[ "$ref" == docker://*@sha256:* ]] && continue
+
               # Require full SHA pin: @<40+ hex chars>
               if ! echo "$ref" | grep -qE '@[0-9a-f]{40}'; then
                 echo "FAIL: $file: $ref"


### PR DESCRIPTION
## Summary

- The `typo3-documentation/render-guides` composite action internally references its own sub-actions (`configure-guides-step`, `render-guides-step`) with `@main`, which violates SHA pinning requirements enforced by consumer repos (e.g. `t3x-nr-llm`)
- Replaces the composite action with direct `docker://` container calls using a pinned image digest
- Two steps (configure + render) instead of one composite action call

## Context

- Failing run: https://github.com/netresearch/t3x-nr-llm/actions/runs/23493568650/job/68368160319#step:1:34
- Error: `The action typo3-documentation/render-guides/.github/actions/configure-guides-step@main is not allowed because all actions must be pinned to a full-length commit SHA`
- Root cause is upstream in `typo3-documentation/render-guides` action.yml

## Test plan

- [ ] Trigger docs workflow in a consumer repo (e.g. `t3x-nr-llm`) after merging
- [ ] Verify documentation renders successfully
- [ ] Verify warnings check still works