### PR TITLE
fix(e2e): scope composer cache key to e2e job and PHP version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,8 +95,8 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-e2e-${{ inputs.php-version }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-e2e-${{ inputs.php-version }}-
 
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-progress


### PR DESCRIPTION
## Summary

- The E2E workflow's composer cache key (`Linux-composer-<hash>`) was too broad, causing `restore-keys: Linux-composer-` to match caches from functional test jobs running different PHP/TYPO3 version combinations
- This led to wrong vendor files being restored, causing `typo3 setup` to fail
- Scoped the cache key to include `e2e` and `inputs.php-version` so it only matches its own caches

## Test plan

- [ ] Verify E2E workflow runs successfully with a clean cache (no cross-job cache collision)
- [ ] Confirm `typo3 setup` completes without vendor mismatch errors