### PR TITLE
refactor: delegate generic workflows to netresearch/.github

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,3 +1,5 @@
+# Moved to netresearch/.github — this wrapper provides backward compatibility.
+# New repos should use: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
 name: Auto-merge dependency PRs
 
 on:
@@ -8,35 +10,8 @@ permissions: {}
 
 jobs:
   auto-merge:
-    name: Auto-merge dependency PRs
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Approve PR
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr review --approve "$PR_URL"
-
-      - name: Enable auto-merge
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          STRATEGY=$(gh api "repos/$REPO" --jq '
-            if .allow_squash_merge then "--squash"
-            elif .allow_merge_commit then "--merge"
-            elif .allow_rebase_merge then "--rebase"
-            else "--squash" end')
-          echo "Using merge strategy: $STRATEGY"
-          gh pr merge --auto "$STRATEGY" "$PR_URL"
+    secrets: inherit

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   analyze:
-    uses: netresearch/.github/.github/workflows/codeql.yml@main
+    uses: netresearch/.github/.github/workflows/codeql.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
     with:
       languages: ${{ inputs.languages }}
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   analyze:
-    uses: netresearch/.github/.github/workflows/codeql.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
+    uses: netresearch/.github/.github/workflows/codeql.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
     with:
       languages: ${{ inputs.languages }}
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   analyze:
-    uses: netresearch/.github/.github/workflows/codeql.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
+    uses: netresearch/.github/.github/workflows/codeql.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
     with:
       languages: ${{ inputs.languages }}
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   analyze:
-    uses: netresearch/.github/.github/workflows/codeql.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
+    uses: netresearch/.github/.github/workflows/codeql.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     with:
       languages: ${{ inputs.languages }}
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,5 @@
+# Moved to netresearch/.github — this wrapper provides backward compatibility.
+# New repos should use: netresearch/.github/.github/workflows/codeql.yml@main
 name: CodeQL
 
 on:
@@ -12,31 +14,11 @@ permissions: {}
 
 jobs:
   analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
+    with:
+      languages: ${{ inputs.languages }}
     permissions:
       contents: read
       security-events: write
       actions: read
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        with:
-          languages: ${{ inputs.languages }}
-          queries: security-and-quality
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        with:
-          category: /language:${{ inputs.languages }}
+    secrets: inherit

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   dependency-review:
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     with:
       fail-on-severity: ${{ inputs.fail-on-severity }}
     permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,3 +1,5 @@
+# Moved to netresearch/.github — this wrapper provides backward compatibility.
+# New repos should use: netresearch/.github/.github/workflows/dependency-review.yml@main
 name: Dependency Review
 
 on:
@@ -12,26 +14,9 @@ permissions: {}
 
 jobs:
   dependency-review:
-    name: Dependency Review
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
+    with:
+      fail-on-severity: ${{ inputs.fail-on-severity }}
     permissions:
       contents: read
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Dependency Review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
-        with:
-          fail-on-severity: ${{ inputs.fail-on-severity }}
-          comment-summary-in-pr: always

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   dependency-review:
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
     with:
       fail-on-severity: ${{ inputs.fail-on-severity }}
     permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   dependency-review:
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
     with:
       fail-on-severity: ${{ inputs.fail-on-severity }}
     permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   dependency-review:
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
     with:
       fail-on-severity: ${{ inputs.fail-on-severity }}
     permissions:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -24,7 +24,7 @@ permissions: {}
 
 jobs:
   greeting:
-    uses: netresearch/.github/.github/workflows/greetings.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
+    uses: netresearch/.github/.github/workflows/greetings.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     with:
       issue-message: ${{ inputs.issue-message }}
       pr-message: ${{ inputs.pr-message }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -24,7 +24,7 @@ permissions: {}
 
 jobs:
   greeting:
-    uses: netresearch/.github/.github/workflows/greetings.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
+    uses: netresearch/.github/.github/workflows/greetings.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
     with:
       issue-message: ${{ inputs.issue-message }}
       pr-message: ${{ inputs.pr-message }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -24,7 +24,7 @@ permissions: {}
 
 jobs:
   greeting:
-    uses: netresearch/.github/.github/workflows/greetings.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
+    uses: netresearch/.github/.github/workflows/greetings.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
     with:
       issue-message: ${{ inputs.issue-message }}
       pr-message: ${{ inputs.pr-message }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,3 +1,5 @@
+# Moved to netresearch/.github — this wrapper provides backward compatibility.
+# New repos should use: netresearch/.github/.github/workflows/greetings.yml@main
 name: Greetings
 
 on:
@@ -22,20 +24,11 @@ permissions: {}
 
 jobs:
   greeting:
-    name: Greet Contributors
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    uses: netresearch/.github/.github/workflows/greetings.yml@main
+    with:
+      issue-message: ${{ inputs.issue-message }}
+      pr-message: ${{ inputs.pr-message }}
     permissions:
       issues: write
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          issue_message: ${{ inputs.issue-message }}
-          pr_message: ${{ inputs.pr-message }}
+    secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -24,7 +24,7 @@ permissions: {}
 
 jobs:
   greeting:
-    uses: netresearch/.github/.github/workflows/greetings.yml@main
+    uses: netresearch/.github/.github/workflows/greetings.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
     with:
       issue-message: ${{ inputs.issue-message }}
       pr-message: ${{ inputs.pr-message }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   label:
-    uses: netresearch/.github/.github/workflows/labeler.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
+    uses: netresearch/.github/.github/workflows/labeler.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     with:
       configuration-path: ${{ inputs.configuration-path }}
     permissions:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,3 +1,5 @@
+# Moved to netresearch/.github — this wrapper provides backward compatibility.
+# New repos should use: netresearch/.github/.github/workflows/labeler.yml@main
 name: PR Labeler
 
 on:
@@ -13,19 +15,10 @@ permissions: {}
 
 jobs:
   label:
-    name: Label PR
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    uses: netresearch/.github/.github/workflows/labeler.yml@main
+    with:
+      configuration-path: ${{ inputs.configuration-path }}
     permissions:
       contents: read
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          configuration-path: ${{ inputs.configuration-path }}
+    secrets: inherit

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   label:
-    uses: netresearch/.github/.github/workflows/labeler.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
+    uses: netresearch/.github/.github/workflows/labeler.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
     with:
       configuration-path: ${{ inputs.configuration-path }}
     permissions:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   label:
-    uses: netresearch/.github/.github/workflows/labeler.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
+    uses: netresearch/.github/.github/workflows/labeler.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
     with:
       configuration-path: ${{ inputs.configuration-path }}
     permissions:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   label:
-    uses: netresearch/.github/.github/workflows/labeler.yml@main
+    uses: netresearch/.github/.github/workflows/labeler.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
     with:
       configuration-path: ${{ inputs.configuration-path }}
     permissions:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,3 +1,5 @@
+# Moved to netresearch/.github — this wrapper provides backward compatibility.
+# New repos should use: netresearch/.github/.github/workflows/lock.yml@main
 name: Lock Threads
 
 on:
@@ -33,23 +35,14 @@ permissions: {}
 
 jobs:
   lock:
-    name: Lock Old Threads
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    uses: netresearch/.github/.github/workflows/lock.yml@main
+    with:
+      issue-inactive-days: ${{ inputs.issue-inactive-days }}
+      pr-inactive-days: ${{ inputs.pr-inactive-days }}
+      issue-lock-reason: ${{ inputs.issue-lock-reason }}
+      pr-lock-reason: ${{ inputs.pr-lock-reason }}
+      log-output: ${{ inputs.log-output }}
     permissions:
       issues: write
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-inactive-days: ${{ inputs.issue-inactive-days }}
-          issue-lock-reason: ${{ inputs.issue-lock-reason }}
-          pr-inactive-days: ${{ inputs.pr-inactive-days }}
-          pr-lock-reason: ${{ inputs.pr-lock-reason }}
-          log-output: ${{ inputs.log-output }}
+    secrets: inherit

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -35,7 +35,7 @@ permissions: {}
 
 jobs:
   lock:
-    uses: netresearch/.github/.github/workflows/lock.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
+    uses: netresearch/.github/.github/workflows/lock.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     with:
       issue-inactive-days: ${{ inputs.issue-inactive-days }}
       pr-inactive-days: ${{ inputs.pr-inactive-days }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -35,7 +35,7 @@ permissions: {}
 
 jobs:
   lock:
-    uses: netresearch/.github/.github/workflows/lock.yml@main
+    uses: netresearch/.github/.github/workflows/lock.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
     with:
       issue-inactive-days: ${{ inputs.issue-inactive-days }}
       pr-inactive-days: ${{ inputs.pr-inactive-days }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -35,7 +35,7 @@ permissions: {}
 
 jobs:
   lock:
-    uses: netresearch/.github/.github/workflows/lock.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
+    uses: netresearch/.github/.github/workflows/lock.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
     with:
       issue-inactive-days: ${{ inputs.issue-inactive-days }}
       pr-inactive-days: ${{ inputs.pr-inactive-days }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -35,7 +35,7 @@ permissions: {}
 
 jobs:
   lock:
-    uses: netresearch/.github/.github/workflows/lock.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
+    uses: netresearch/.github/.github/workflows/lock.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
     with:
       issue-inactive-days: ${{ inputs.issue-inactive-days }}
       pr-inactive-days: ${{ inputs.pr-inactive-days }}

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -25,7 +25,7 @@ permissions: {}
 
 jobs:
   quality-gate:
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
     with:
       size-warning-threshold: ${{ inputs.size-warning-threshold }}
       size-alert-threshold: ${{ inputs.size-alert-threshold }}

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -25,7 +25,7 @@ permissions: {}
 
 jobs:
   quality-gate:
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
     with:
       size-warning-threshold: ${{ inputs.size-warning-threshold }}
       size-alert-threshold: ${{ inputs.size-alert-threshold }}

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -25,7 +25,7 @@ permissions: {}
 
 jobs:
   quality-gate:
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     with:
       size-warning-threshold: ${{ inputs.size-warning-threshold }}
       size-alert-threshold: ${{ inputs.size-alert-threshold }}

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -25,7 +25,7 @@ permissions: {}
 
 jobs:
   quality-gate:
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
     with:
       size-warning-threshold: ${{ inputs.size-warning-threshold }}
       size-alert-threshold: ${{ inputs.size-alert-threshold }}

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,3 +1,5 @@
+# Moved to netresearch/.github — this wrapper provides backward compatibility.
+# New repos should use: netresearch/.github/.github/workflows/pr-quality.yml@main
 name: PR Quality Gates
 
 on:
@@ -23,91 +25,12 @@ permissions: {}
 
 jobs:
   quality-gate:
-    name: Quality Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: github.event.pull_request.draft == false
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
+    with:
+      size-warning-threshold: ${{ inputs.size-warning-threshold }}
+      size-alert-threshold: ${{ inputs.size-alert-threshold }}
+      security-controls-path: ${{ inputs.security-controls-path }}
     permissions:
       contents: read
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: PR Size Check
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          SIZE_WARNING: ${{ inputs.size-warning-threshold }}
-          SIZE_ALERT: ${{ inputs.size-alert-threshold }}
-        with:
-          script: |
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
-
-            const additions = files.reduce((sum, f) => sum + f.additions, 0);
-            const deletions = files.reduce((sum, f) => sum + f.deletions, 0);
-            const total = additions + deletions;
-
-            const warning = parseInt(process.env.SIZE_WARNING);
-            const alert = parseInt(process.env.SIZE_ALERT);
-
-            let size = 'small';
-            if (total > warning) size = 'large';
-            else if (total > Math.floor(warning / 2.5)) size = 'medium';
-
-            console.log(`PR Size: ${size} (${additions}+ / ${deletions}-)`); 
-
-            if (total > alert) {
-              core.warning(`Large PR with ${total} changes. Consider breaking into smaller PRs.`);
-            }
-
-  auto-approve:
-    name: Auto-Approve (Solo Maintainer)
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: quality-gate
-    if: github.event.pull_request.draft == false
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Auto-approve PR
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          CONTROLS_PATH: ${{ inputs.security-controls-path }}
-        with:
-          script: |
-            const controlsPath = process.env.CONTROLS_PATH;
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              event: 'APPROVE',
-              body: `**Automated approval for solo maintainer project**
-
-            This PR has passed all automated quality gates:
-            - ✅ Static analysis (PHPStan)
-            - ✅ Code style (PHP-CS-Fixer)
-            - ✅ Unit & functional tests
-            - ✅ Security scanning
-            - ✅ Dependency review
-
-            See [SECURITY_CONTROLS.md](/${controlsPath}) for compensating controls documentation.`
-            });
-
-            console.log('PR auto-approved with compensating controls documentation');
+    secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   analysis:
-    uses: netresearch/.github/.github/workflows/scorecard.yml@main
+    uses: netresearch/.github/.github/workflows/scorecard.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   analysis:
-    uses: netresearch/.github/.github/workflows/scorecard.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
+    uses: netresearch/.github/.github/workflows/scorecard.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   analysis:
-    uses: netresearch/.github/.github/workflows/scorecard.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
+    uses: netresearch/.github/.github/workflows/scorecard.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,3 +1,5 @@
+# Moved to netresearch/.github — this wrapper provides backward compatibility.
+# New repos should use: netresearch/.github/.github/workflows/scorecard.yml@main
 name: OpenSSF Scorecard
 
 on:
@@ -7,33 +9,10 @@ permissions: {}
 
 jobs:
   analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
     permissions:
       contents: read
       security-events: write
       id-token: write
       actions: read
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Run Scorecard
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        with:
-          sarif_file: results.sarif
+    secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   analysis:
-    uses: netresearch/.github/.github/workflows/scorecard.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
+    uses: netresearch/.github/.github/workflows/scorecard.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ permissions: {}
 
 jobs:
   gitleaks:
-    uses: netresearch/.github/.github/workflows/gitleaks.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
     with:
       skip: ${{ inputs.skip-gitleaks }}
     secrets:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ permissions: {}
 
 jobs:
   gitleaks:
-    uses: netresearch/.github/.github/workflows/gitleaks.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     with:
       skip: ${{ inputs.skip-gitleaks }}
     secrets:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,3 +1,5 @@
+# Gitleaks moved to netresearch/.github — composer-audit stays here (PHP-specific).
+# New repos should use: netresearch/.github/.github/workflows/gitleaks.yml@main
 name: Security
 
 on:
@@ -27,33 +29,11 @@ permissions: {}
 
 jobs:
   gitleaks:
-    name: Secret Scanning
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: >-
-      !inputs.skip-gitleaks &&
-      github.event_name != 'merge_group' &&
-      github.actor != 'dependabot[bot]'
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    with:
+      skip: ${{ inputs.skip-gitleaks }}
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   composer-audit:
     name: Composer Audit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ permissions: {}
 
 jobs:
   gitleaks:
-    uses: netresearch/.github/.github/workflows/gitleaks.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
     with:
       skip: ${{ inputs.skip-gitleaks }}
     secrets:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ permissions: {}
 
 jobs:
   gitleaks:
-    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
     with:
       skip: ${{ inputs.skip-gitleaks }}
     secrets:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -65,7 +65,7 @@ permissions: {}
 
 jobs:
   stale:
-    uses: netresearch/.github/.github/workflows/stale.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
+    uses: netresearch/.github/.github/workflows/stale.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     with:
       days-before-stale: ${{ inputs.days-before-stale }}
       days-before-close: ${{ inputs.days-before-close }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -65,7 +65,7 @@ permissions: {}
 
 jobs:
   stale:
-    uses: netresearch/.github/.github/workflows/stale.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
+    uses: netresearch/.github/.github/workflows/stale.yml@719efa1363a09402610a5e515f668eff54ec4e23 # main
     with:
       days-before-stale: ${{ inputs.days-before-stale }}
       days-before-close: ${{ inputs.days-before-close }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,5 @@
+# Moved to netresearch/.github — this wrapper provides backward compatibility.
+# New repos should use: netresearch/.github/.github/workflows/stale.yml@main
 name: Stale Issues
 
 on:
@@ -63,29 +65,18 @@ permissions: {}
 
 jobs:
   stale:
-    name: Close Stale Issues
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    uses: netresearch/.github/.github/workflows/stale.yml@main
+    with:
+      days-before-stale: ${{ inputs.days-before-stale }}
+      days-before-close: ${{ inputs.days-before-close }}
+      exempt-issue-labels: ${{ inputs.exempt-issue-labels }}
+      exempt-pr-labels: ${{ inputs.exempt-pr-labels }}
+      operations-per-run: ${{ inputs.operations-per-run }}
+      stale-issue-message: ${{ inputs.stale-issue-message }}
+      stale-pr-message: ${{ inputs.stale-pr-message }}
+      close-issue-message: ${{ inputs.close-issue-message }}
+      close-pr-message: ${{ inputs.close-pr-message }}
     permissions:
       issues: write
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: ${{ inputs.stale-issue-message }}
-          stale-pr-message: ${{ inputs.stale-pr-message }}
-          close-issue-message: ${{ inputs.close-issue-message }}
-          close-pr-message: ${{ inputs.close-pr-message }}
-          days-before-stale: ${{ inputs.days-before-stale }}
-          days-before-close: ${{ inputs.days-before-close }}
-          stale-issue-label: stale
-          stale-pr-label: stale
-          exempt-issue-labels: ${{ inputs.exempt-issue-labels }}
-          exempt-pr-labels: ${{ inputs.exempt-pr-labels }}
-          operations-per-run: ${{ inputs.operations-per-run }}
+    secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -65,7 +65,7 @@ permissions: {}
 
 jobs:
   stale:
-    uses: netresearch/.github/.github/workflows/stale.yml@main
+    uses: netresearch/.github/.github/workflows/stale.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
     with:
       days-before-stale: ${{ inputs.days-before-stale }}
       days-before-close: ${{ inputs.days-before-close }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -65,7 +65,7 @@ permissions: {}
 
 jobs:
   stale:
-    uses: netresearch/.github/.github/workflows/stale.yml@ac02398d6b2413d9677ec97763b4c8173b605695 # main
+    uses: netresearch/.github/.github/workflows/stale.yml@d88eed9ac412c7e6f05bbdb93824a5175a054a65 # main
     with:
       days-before-stale: ${{ inputs.days-before-stale }}
       days-before-close: ${{ inputs.days-before-close }}


### PR DESCRIPTION
## Summary

- Replaces 9 generic workflows with thin wrappers delegating to `netresearch/.github`
- Splits gitleaks from `security.yml` into org-wide `gitleaks.yml` (delegates to `.github`)
- All wrapper interfaces are backward-compatible — existing callers won't break

**Moved workflows:** auto-merge-deps, codeql, dependency-review, greetings, labeler, lock, pr-quality, scorecard, stale

## Test plan

- [ ] Verify existing TYPO3 repo CI still passes (wrappers delegate correctly)
- [ ] Verify TYPO3-specific workflows untouched