### PR TITLE
feat(security): add Opengrep SAST to shared security.yml (active by default)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,16 @@ on:
         required: false
         type: boolean
         default: false
+      skip-opengrep:
+        description: 'Skip Opengrep SAST scanning'
+        required: false
+        type: boolean
+        default: false
+      opengrep-config:
+        description: 'Opengrep rules argument (one or more --config tokens, space-separated)'
+        required: false
+        type: string
+        default: '--config auto'
 
 permissions: {}
 
@@ -62,3 +72,53 @@ jobs:
 
       - name: Run Composer Audit
         run: composer audit --format=plain --abandoned=report
+
+  opengrep:
+    name: SAST (Opengrep)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ !inputs.skip-opengrep }}
+    permissions:
+      contents: read
+      security-events: write
+    env:
+      # Pinned Opengrep release — bump via renovate/manual PR. Binary is
+      # verified by SHA256 below; update both values together.
+      OPENGREP_VERSION: v1.19.0
+      OPENGREP_SHA256: 1d69a41beb88e8e7917f26cc6a16c1edf298f31402807e6d1afbb5d8684c3590
+      OPENGREP_CONFIG: ${{ inputs.opengrep-config }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Opengrep
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL -o "$HOME/.local/bin/opengrep" \
+            "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
+          echo "${OPENGREP_SHA256}  $HOME/.local/bin/opengrep" | sha256sum -c -
+          chmod +x "$HOME/.local/bin/opengrep"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run Opengrep scan
+        # Report-only: findings go to the Security tab via SARIF upload.
+        # We intentionally do not pass --error so existing repos aren't
+        # suddenly blocked — teams can triage baselines, then tighten via
+        # a follow-up PR that flips --error on.
+        run: |
+          # shellcheck disable=SC2086  # $OPENGREP_CONFIG contains multiple --config flags
+          opengrep scan $OPENGREP_CONFIG --sarif --output opengrep.sarif .
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: opengrep.sarif
+          category: opengrep

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ gh api repos/netresearch/REPO/hooks --method POST \
 
 | Workflow | Purpose | Trigger |
 |----------|---------|---------|
-| [`security.yml`](#security) | Gitleaks secret scanning + Composer audit | push, PR |
+| [`security.yml`](#security) | Composer audit + Opengrep SAST | push, PR |
 | [`codeql.yml`](#codeql) | GitHub CodeQL security scanning | push, schedule |
 | [`dependency-review.yml`](#dependency-review) | Dependency vulnerability review | PR only |
 | [`license-check.yml`](#license-check) | PHP dependency license audit | push, PR |
@@ -355,7 +355,7 @@ jobs:
 
 ## Security
 
-Gitleaks secret scanning and Composer dependency audit.
+Composer dependency audit and [Opengrep](https://github.com/opengrep/opengrep) SAST (the fully-OSS LGPL-2.1 fork of Semgrep). Both jobs run by default; Opengrep findings surface in the repo's **Security** tab via SARIF upload and do **not** fail CI — flip `--error` in `opengrep-config` to make them blocking once baselines are triaged.
 
 ### Minimal caller
 
@@ -366,8 +366,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    secrets:
-      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 ```
 
 ### Inputs
@@ -375,14 +373,9 @@ jobs:
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `php-version` | string | `8.4` | PHP version for Composer audit |
-| `skip-gitleaks` | boolean | `false` | Skip Gitleaks secret scanning |
 | `skip-composer-audit` | boolean | `false` | Skip Composer dependency audit |
-
-### Secrets
-
-| Secret | Required | Description |
-|--------|----------|-------------|
-| `GITLEAKS_LICENSE` | No | License key for Gitleaks |
+| `skip-opengrep` | boolean | `false` | Skip Opengrep SAST scanning |
+| `opengrep-config` | string | `--config auto` | Opengrep rules argument (one or more `--config` tokens, space-separated, e.g. `--config p/php --config p/security-audit`) |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an [Opengrep](https://github.com/opengrep/opengrep) SAST job to the shared [`security.yml`](https://github.com/netresearch/typo3-ci-workflows/blob/main/.github/workflows/security.yml) reusable workflow. Every caller (≈18+ netresearch repos — [`t3x-*`](https://github.com/orgs/netresearch/repositories?q=t3x), DHL modules, SDKs, TYPO3 extensions) picks it up on the next push **without any change to caller workflows**.

Opengrep is the LGPL-2.1 fork of Semgrep — same CLI / rule syntax, no account required for `--config auto`, no CC-BY-NC-SA license drag on community rules. Complements the existing CodeQL + Composer-audit + Gitleaks coverage with pattern-based SAST (especially strong for PHP, where CodeQL is weaker).

### What runs

```yaml
- run: opengrep scan --config auto --sarif --output opengrep.sarif .
- uses: github/codeql-action/upload-sarif@... # v4.34.1
  with: { sarif_file: opengrep.sarif, category: opengrep }
```

### Rollout posture: **active but report-only**

- `skip-opengrep: false` by default → runs everywhere
- No `--error` flag → findings go to the **Security** tab via SARIF, but don't fail CI
- Teams can triage baselines, then tighten by overriding `opengrep-config: '--config auto --error'` when ready

This avoids suddenly blocking merges on 18+ repos that have never seen a SAST scan before.

### Inputs

| Input | Default | Purpose |
|---|---|---|
| `skip-opengrep` | `false` | Opt out per-caller if needed |
| `opengrep-config` | `--config auto` | Override rulesets (e.g. `--config p/php --config p/security-audit`, or a local `.opengrep.yml`) |

### Supply-chain hardening

- `OPENGREP_VERSION` pinned to `v1.19.0`
- Binary verified via `sha256sum -c` against `OPENGREP_SHA256=1d69a41beb88e8e7917f26cc6a16c1edf298f31402807e6d1afbb5d8684c3590`
- Installed to `$HOME/.local/bin` via `$GITHUB_PATH` (no sudo)
- `harden-runner`, pinned action SHAs, minimal `permissions:`

## Test plan

- [x] `actionlint .github/workflows/security.yml` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` — valid YAML
- [x] Smoke test of the exact scan command against a tainted PHP fixture locally (`opengrep scan --config auto --sarif --output opengrep.sarif .`) — produced SARIF with `php.lang.security.injection.tainted-sql-string` + `eval-use` findings, non-zero rules ran (85)
- [x] Binary SHA verified against `gh api repos/opengrep/opengrep/releases/latest`
- [ ] CI on this PR exercises the new job via self-ci / downstream-caller