### PR TITLE
feat(security): flip Opengrep default to blocking (WARNING+ fails CI)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,10 +19,10 @@ on:
         type: boolean
         default: false
       opengrep-config:
-        description: 'Opengrep rules argument (one or more --config tokens, space-separated)'
+        description: 'Opengrep scan arguments (rules + behavior flags). Default blocks CI on WARNING+ findings; override to e.g. "--config auto" for report-only or "--config auto --error --severity ERROR" for looser gating.'
         required: false
         type: string
-        default: '--config auto'
+        default: '--config auto --error --severity WARNING'
 
 permissions: {}
 
@@ -108,12 +108,12 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run Opengrep scan
-        # Report-only: findings go to the Security tab via SARIF upload.
-        # We intentionally do not pass --error so existing repos aren't
-        # suddenly blocked — teams can triage baselines, then tighten via
-        # a follow-up PR that flips --error on.
+        # Default config (--error --severity WARNING) fails this step on
+        # WARNING+ findings. The SARIF file is still written on failure,
+        # and the upload step below runs with if: always() so findings
+        # land in the Security tab even when CI is blocked.
         run: |
-          # shellcheck disable=SC2086  # $OPENGREP_CONFIG contains multiple --config flags
+          # shellcheck disable=SC2086  # $OPENGREP_CONFIG contains multiple flags
           opengrep scan $OPENGREP_CONFIG --sarif --output opengrep.sarif .
 
       - name: Upload SARIF to code scanning

--- a/README.md
+++ b/README.md
@@ -355,7 +355,9 @@ jobs:
 
 ## Security
 
-Composer dependency audit and [Opengrep](https://github.com/opengrep/opengrep) SAST (the fully-OSS LGPL-2.1 fork of Semgrep). Both jobs run by default; Opengrep findings surface in the repo's **Security** tab via SARIF upload and do **not** fail CI — flip `--error` in `opengrep-config` to make them blocking once baselines are triaged.
+Composer dependency audit and [Opengrep](https://github.com/opengrep/opengrep) SAST (the fully-OSS LGPL-2.1 fork of Semgrep). Both jobs run by default.
+
+Opengrep **blocks CI on findings at severity WARNING or higher** and also uploads SARIF to the repo's **Security** tab. Override `opengrep-config` to tune the threshold — e.g. drop `--error` for pure report-only, or raise `--severity ERROR` to only block on critical findings.
 
 ### Minimal caller
 
@@ -375,7 +377,7 @@ jobs:
 | `php-version` | string | `8.4` | PHP version for Composer audit |
 | `skip-composer-audit` | boolean | `false` | Skip Composer dependency audit |
 | `skip-opengrep` | boolean | `false` | Skip Opengrep SAST scanning |
-| `opengrep-config` | string | `--config auto` | Opengrep rules argument (one or more `--config` tokens, space-separated, e.g. `--config p/php --config p/security-audit`) |
+| `opengrep-config` | string | `--config auto --error --severity WARNING` | Opengrep scan arguments (rules + behavior flags). Drop `--error` for report-only, use `--severity ERROR` for looser gating, or set `--severity INFO` to also block on informational findings. |
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to [#51](https://github.com/netresearch/typo3-ci-workflows/pull/51). Flips the Opengrep default from report-only to **blocking on WARNING+ severity findings**.

Default `opengrep-config` changes:
```diff
- '--config auto'
+ '--config auto --error --severity WARNING'
```

SARIF upload still runs on scan failure (`upload-sarif` has `if: always()`, and Opengrep writes the SARIF before exiting), so findings land in the **Security** tab even when CI is red.

## Why now, not later

A local sweep across six active callers after #51 merged:

| Repo | Findings | Severity |
|---|---|---|
| [t3x-nr-llm](https://github.com/netresearch/t3x-nr-llm) | 0 | — |
| [t3x-cowriter](https://github.com/netresearch/t3x-cowriter) | 0 | — |
| [t3x-nr-saml-auth](https://github.com/netresearch/t3x-nr-saml-auth) | 0 | — |
| [t3x-nr-vault](https://github.com/netresearch/t3x-nr-vault) | 0 | — |
| [t3x-scheduler](https://github.com/netresearch/t3x-scheduler) | 0 | — |
| [t3x-nr-textdb](https://github.com/netresearch/t3x-nr-textdb) | 3 | all INFO |

None of the sampled repos would break on the WARNING threshold today. Report-only would just let findings rot in the Security tab with nobody looking; blocking CI turns any future regression into an actionable failure on the PR that introduces it.

## Escape hatches for the unusual case

| Situation | Caller override |
|---|---|
| Repo under modernization, want report-only | `opengrep-config: --config auto` |
| Only block on critical (RCE, SQLi, XXE) | `opengrep-config: --config auto --error --severity ERROR` |
| Block on everything incl. INFO | `opengrep-config: --config auto --error --severity INFO` |
| Stop the scan entirely | `skip-opengrep: true` |

## Test plan

- [x] `actionlint .github/workflows/security.yml` — clean
- [x] Empirical: `opengrep scan --config auto --error --severity WARNING` exits 1 on real findings, exits 0 on clean tree
- [x] Empirical: SARIF file is fully written (1.3 MB, `.runs[0].results` populated) even when scan exits 1
- [ ] Self-CI run on this PR