### PR TITLE
fix(security): address post-merge review on Opengrep rollout (#51, #53)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -112,9 +112,14 @@ jobs:
         # WARNING+ findings. The SARIF file is still written on failure,
         # and the upload step below runs with if: always() so findings
         # land in the Security tab even when CI is blocked.
+        #
+        # `read -ra` tokenises OPENGREP_CONFIG on whitespace into an array
+        # WITHOUT glob expansion or word-splitting surprises. Passing
+        # "${ARGS[@]}" preserves each arg as a single argv entry, so
+        # callers cannot inject shell syntax via this input.
         run: |
-          # shellcheck disable=SC2086  # $OPENGREP_CONFIG contains multiple flags
-          opengrep scan $OPENGREP_CONFIG --sarif --output opengrep.sarif .
+          read -ra ARGS <<< "$OPENGREP_CONFIG"
+          opengrep scan "${ARGS[@]}" --sarif --output opengrep.sarif .
 
       - name: Upload SARIF to code scanning
         if: always()

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    secrets:
-      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 ```
 
 ```yaml
@@ -357,7 +355,11 @@ jobs:
 
 Composer dependency audit and [Opengrep](https://github.com/opengrep/opengrep) SAST (the fully-OSS LGPL-2.1 fork of Semgrep). Both jobs run by default.
 
-Opengrep **blocks CI on findings at severity WARNING or higher** and also uploads SARIF to the repo's **Security** tab. Override `opengrep-config` to tune the threshold — e.g. drop `--error` for pure report-only, or raise `--severity ERROR` to only block on critical findings.
+Opengrep **blocks CI on findings at severity WARNING or higher** and also uploads SARIF to the repo's **Security** tab. Override `opengrep-config` to tune behavior:
+
+- **Report-only (all findings, CI never fails):** `--config auto` — drop both `--error` and `--severity` so every finding reaches the Security tab without gating merges.
+- **Block only on critical (RCE/SQLi/XXE):** `--config auto --error --severity ERROR`.
+- **Block on everything, including INFO:** `--config auto --error --severity INFO`.
 
 ### Minimal caller
 
@@ -377,7 +379,7 @@ jobs:
 | `php-version` | string | `8.4` | PHP version for Composer audit |
 | `skip-composer-audit` | boolean | `false` | Skip Composer dependency audit |
 | `skip-opengrep` | boolean | `false` | Skip Opengrep SAST scanning |
-| `opengrep-config` | string | `--config auto --error --severity WARNING` | Opengrep scan arguments (rules + behavior flags). Drop `--error` for report-only, use `--severity ERROR` for looser gating, or set `--severity INFO` to also block on informational findings. |
+| `opengrep-config` | string | `--config auto --error --severity WARNING` | Opengrep scan arguments (rules + behavior flags). See the [overrides above](#security) for report-only, ERROR-only, and INFO-blocking variants. |
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses three valid review threads that landed after [#51](https://github.com/netresearch/typo3-ci-workflows/pull/51) and [#53](https://github.com/netresearch/typo3-ci-workflows/pull/53) merged.

### 1. Orphaned `GITLEAKS_LICENSE` in quickstart

The "Recommended additions" snippet in README still passed `GITLEAKS_LICENSE` as a secret to `security.yml`, but that secret was removed from the workflow in [`8c4336d`](https://github.com/netresearch/typo3-ci-workflows/commit/8c4336d) when Gitleaks moved to [`netresearch/.github/gitleaks.yml`](https://github.com/netresearch/.github/blob/main/.github/workflows/gitleaks.yml). The `secrets:` block was a no-op and misleading. Dropped.

### 2. Unquoted `$OPENGREP_CONFIG` — shell-injection hardening

The scan step ran `opengrep scan \$OPENGREP_CONFIG ...` unquoted so the input went through bash word-splitting + glob expansion. Switched to:

```bash
read -ra ARGS <<< "\$OPENGREP_CONFIG"
opengrep scan "\${ARGS[@]}" --sarif --output opengrep.sarif .
```

Verified locally — feeding a malicious `--config auto; rm -rf /tmp/test` produces five argv tokens passed to the opengrep binary (which would then reject them as unknown options), **not** a shell command. Neutralises the injection surface even though callers are in-org.

### 3. Misleading "drop `--error`" prose

After #53 set the default to `--config auto --error --severity WARNING`, the README prose \"drop \`--error\` for report-only\" was incomplete: dropping only \`--error\` still leaves \`--severity WARNING\`, filtering out INFO findings. Replaced with an explicit bulleted list of the three realistic override postures:

- report-only (all findings, CI never fails): `--config auto`
- block only on critical (RCE/SQLi/XXE): `--config auto --error --severity ERROR`
- block on everything incl. INFO: `--config auto --error --severity INFO`

## Test plan

- [x] `actionlint .github/workflows/security.yml` — clean
- [x] `read -ra` tokenisation test (normal input → 5 correct tokens; malicious input → 5 inert tokens, no shell exec)
- [ ] Self-CI on this PR