### PR TITLE
fix(publish-to-ter): derive tag from ext_emconf.php on manual dispatch

### DIFF
--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -40,6 +40,7 @@ jobs:
         id: version
         env:
           GIT_REF: ${{ github.ref }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Extract version from ext_emconf.php (single source of truth)
           if [[ ! -f ext_emconf.php ]]; then
@@ -67,8 +68,28 @@ jobs:
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "Version $VERSION (from tag $TAG)"
           else
-            echo "tag=" >> "$GITHUB_OUTPUT"
-            echo "Version $VERSION (manual trigger)"
+            # Manual workflow_dispatch from a branch: GitHub rejects
+            # `--ref <tag>` for workflows whose file doesn't exist at that
+            # tag (common for older tags pre-dating a workflow addition), so
+            # callers dispatch against a branch instead. Derive the matching
+            # release tag from the ext_emconf.php version so the
+            # "Get release comment" step can still fetch the GitHub release
+            # body as the TER upload comment. Try 'v${VERSION}' first
+            # (signed-tag convention), fall back to bare '${VERSION}'
+            # (historic).
+            TAG=""
+            if gh release view "v${VERSION}" --json tagName --jq .tagName >/dev/null 2>&1; then
+              TAG="v${VERSION}"
+            elif gh release view "${VERSION}" --json tagName --jq .tagName >/dev/null 2>&1; then
+              TAG="${VERSION}"
+            fi
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            if [[ -n "$TAG" ]]; then
+              echo "Version $VERSION (manual trigger, derived release tag: $TAG)"
+            else
+              echo "::warning::No GitHub release found for version $VERSION (tried 'v$VERSION' and '$VERSION') -- TER upload comment will be the default short link"
+              echo "Version $VERSION (manual trigger, no matching release tag)"
+            fi
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

When callers use the \`workflow_dispatch\`-only pattern (see [t3x-nr-llm](https://github.com/netresearch/t3x-nr-llm/blob/main/.github/workflows/ter-publish.yml), [t3x-nr-mcp-agent](https://github.com/netresearch/t3x-nr-mcp-agent/blob/main/.github/workflows/ter-publish.yml), and [t3x-nr-image-optimize](https://github.com/netresearch/t3x-nr-image-optimize/blob/main/.github/workflows/ter-publish.yml)), GitHub rejects \`--ref <tag>\` with HTTP 422 *\"Workflow does not have 'workflow_dispatch' trigger\"* whenever the caller workflow file doesn't exist at that tag — common for older tags pre-dating the caller's introduction. Callers therefore dispatch against a branch (\`--ref main\`, \`--ref TYPO3_12\`).

## Problem

Before this fix, a branch-dispatch left \`$TAG\` empty in the \"Resolve version\" step, which caused the \"Get release comment\" step to skip the \`gh release view \"$TAG\"\` lookup and fall through to the minimal default:

```
Released version X.Y.Z -- for details see {SERVER_URL}/{REPO}/releases
```

Anyone dispatching a re-publish to refresh the TER upload comment after editing the GitHub release body got this short link back, **not** the actual release notes. Observed concretely on [t3x-nr-image-optimize v2.2.2](https://github.com/netresearch/t3x-nr-image-optimize/releases/tag/v2.2.2) (197 commits misnamed as a patch release; the whole point of re-dispatching was to get the honest notes into TER's upload comment).

## Fix

When \`\$GIT_REF\` is not a tag ref, query the GitHub API for a release matching the \`ext_emconf.php\` version, trying \`v\${VERSION}\` first (modern signed-tag convention) and falling back to bare \`\${VERSION}\` (historic TYPO3_12-style tags). If either release exists, \`\$TAG\` is populated and the downstream comment step fetches the release body as intended. If neither matches, a warning annotation is emitted and the existing default-comment path stays in effect.

Also adds \`GH_TOKEN: \${{ github.token }}\` to the step's env so \`gh release view\` has an authenticated session (the default \`github.token\` already has read access to releases — no new secrets / permissions needed).

## Test plan

- [x] Syntax-checked locally (yamllint / workflow parser)
- [ ] After merge: re-dispatch \`ter-publish.yml\` on t3x-nr-image-optimize \`main\` and \`TYPO3_12\`, verify the TER upload comment on [v2.2.2](https://extensions.typo3.org/extension/nr_image_optimize/2.2.2) and [v1.1.1](https://extensions.typo3.org/extension/nr_image_optimize/1.1.1) matches the release body
- [ ] Manually dispatch with a version that has no matching release (e.g. bump \`ext_emconf.php\` then dispatch before tagging) to verify the warning path still produces the default comment instead of failing the job

## Backwards compatibility

- Tag-triggered publishes (the 99% case) are unchanged — the new branch only runs when \`\$GIT_REF\` is not \`refs/tags/*\`.
- Callers that were relying on the empty-tag fallback behaviour (minimal default comment) will now get the release body if one exists; that's a strict improvement. If no release exists, the fallback is preserved verbatim.