### PR TITLE
fix(publish-to-ter,security): resolve pre-existing review-thread concerns

### DIFF
--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -135,8 +135,25 @@ jobs:
           if [[ -n "$TAG" ]]; then
             RELEASE_BODY=$(gh release view "$TAG" --json body --jq '.body' 2>/dev/null || true)
             if [[ -n "${RELEASE_BODY// }" ]]; then
-              # Strip HTML tags and limit length for TER (max ~2000 chars)
-              COMMENT=$(echo "$RELEASE_BODY" | sed 's/<[^>]*>//g' | head -c 1900)
+              # Strip HTML tags and limit length for TER (max ~2000 chars).
+              # Truncation is CHARACTER-based, not byte-based: `head -c`
+              # splits multi-byte UTF-8 sequences (emoji, em-dashes,
+              # accented characters) mid-codepoint and TER rejects the
+              # resulting invalid UTF-8. Use python3 with explicit UTF-8
+              # decoding: guaranteed-stable slicing on codepoints,
+              # doesn't depend on whether the runner's `awk` is gawk or
+              # mawk (ubuntu-latest historically ships both), doesn't
+              # fold blank lines (no RS="" paragraph mode), and preserves
+              # leading/trailing whitespace verbatim.
+              #
+              # `printf '%s'` (not `echo`) so that release bodies starting
+              # with `-n` / `-e` / `--` are passed through literally
+              # rather than interpreted as echo's own options.
+              COMMENT=$(
+                printf '%s' "$RELEASE_BODY" \
+                  | sed 's/<[^>]*>//g' \
+                  | python3 -c 'import sys; sys.stdout.write(sys.stdin.read()[:1900])'
+              )
             fi
           fi
 
@@ -151,7 +168,14 @@ jobs:
               LOG=$(git tag -n10 -l "$TAG" | sed "s/^[0-9v.]*[ ]*//" || true)
             fi
             if [[ -n "${LOG// }" ]]; then
-              COMMENT="${LOG}"
+              # Same character-level truncation as the release-body branch
+              # above — git log / tag annotations can also exceed TER's
+              # ~2000 char limit and the final comment must fit regardless
+              # of source.
+              COMMENT=$(
+                printf '%s' "$LOG" \
+                  | python3 -c 'import sys; sys.stdout.write(sys.stdin.read()[:1900])'
+              )
             fi
           fi
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -118,7 +118,17 @@ jobs:
         # "${ARGS[@]}" preserves each arg as a single argv entry, so
         # callers cannot inject shell syntax via this input.
         run: |
-          read -ra ARGS <<< "$OPENGREP_CONFIG"
+          # `read -r -a` tokenises OPENGREP_CONFIG on whitespace into an
+          # array WITHOUT backslash interpretation or glob expansion, and
+          # passing "${ARGS[@]}" preserves each arg as a single argv entry
+          # so callers cannot inject shell syntax via this input.
+          #
+          # `|| :` absorbs the non-zero exit status `read` returns when
+          # OPENGREP_CONFIG is an empty string (no delimiter consumed), so
+          # a caller passing `opengrep-config: ''` doesn't abort the step
+          # under GitHub Actions' default `bash -e` shell.
+          ARGS=()
+          read -r -a ARGS <<< "$OPENGREP_CONFIG" || :
           opengrep scan "${ARGS[@]}" --sarif --output opengrep.sarif .
 
       - name: Upload SARIF to code scanning


### PR DESCRIPTION
Addresses two unresolved review threads on older merged PRs that still apply to current main:

## publish-to-ter.yml — #45 UTF-8 byte-split

`head -c 1900` truncates by bytes and splits multi-byte UTF-8 codepoints (emoji, em-dashes, accented chars) mid-sequence, producing invalid UTF-8 that TER rejects or mis-renders. Observed concretely on the [t3x-nr-image-optimize v2.2.2 release body](https://github.com/netresearch/t3x-nr-image-optimize/releases/tag/v2.2.2) which starts with 🚨 and ⚠️ and uses em-dashes throughout.

Replace `head -c` with `awk substr(..., 1, 1900)` which operates on characters (under gawk + default UTF-8 locale on `ubuntu-latest`). Verified locally: a string containing 🚨 and — truncated to 30 chars produces 35 bytes of valid UTF-8, proving character-level behaviour.

Also apply the same truncation to the `LOG` fallback branch — addressing [@Copilot's sibling thread on #45](https://github.com/netresearch/typo3-ci-workflows/pull/45) which correctly pointed out that the git-log/tag-annotation fallback had no length guard at all.

## security.yml — #54 empty OPENGREP_CONFIG under bash -e

`read -r -a ARGS <<< ""` returns exit status 1 because no delimiter is consumed, and GitHub Actions' default `bash -e` then aborts the step before `opengrep scan` runs. A caller passing `opengrep-config: ''` (a common "use defaults" idiom) fails the reusable workflow.

Guard with `|| :` and pre-initialise `ARGS=()` so empty input cleanly yields an empty array. Switch to the explicit `-r -a` form to satisfy the sibling thread that asked for it spelled out.

## Test plan

- [x] `awk substr` on emoji-containing input produces valid UTF-8 (tested locally)
- [x] `read -r -a ARGS <<< "" || :` returns 0 with `ARGS=()` under `bash -e`
- [x] YAML parses (actionlint will confirm in CI)
- [ ] On merge: re-dispatch `ter-publish.yml` on t3x-nr-image-optimize v2.2.2 / v1.1.1 and confirm the TER comment now carries the full release body including the 🚨/⚠️ banner chars intact