### PR TITLE
fix(e2e): pre-seed settings.php to unblock typo3 setup on v14.2+

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,6 +119,38 @@ jobs:
             exit 1
           fi
 
+          # Pre-seed a minimal settings.php so the DI container can resolve
+          # Messenger\DoctrineTransportFactory during CLI bootstrap. TYPO3 v14.2
+          # resolves this factory before `typo3 setup` writes the DB config,
+          # and the factory dereferences
+          # $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] — if
+          # that array key is missing, Doctrine DBAL throws
+          # `DriverManager::getConnection(): Argument #1 must be of type array,
+          # null given`. `typo3 setup --force` then overwrites the file with
+          # the real installation config.
+          mkdir -p config/system
+          cat > config/system/settings.php << 'PHPEOF'
+          <?php
+          return [
+              'DB' => [
+                  'Connections' => [
+                      'Default' => [
+                          'driver' => 'mysqli',
+                          'host' => '127.0.0.1',
+                          'port' => 3306,
+                          'dbname' => 'typo3',
+                          'user' => 'root',
+                          'password' => 'root',
+                          'charset' => 'utf8mb4',
+                      ],
+                  ],
+              ],
+              'SYS' => [
+                  'encryptionKey' => 'ci-e2e-placeholder-overwritten-by-typo3-setup--force',
+              ],
+          ];
+          PHPEOF
+
           # Setup TYPO3
           .Build/bin/typo3 setup \
             --driver=mysqli \


### PR DESCRIPTION
## Summary

TYPO3 v14.2.0 introduced a boot-order bug: `bin/typo3 setup` fails before running because the DI container eagerly resolves `Messenger\DoctrineTransportFactory`, which reads `\$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']`. On a fresh install that array key doesn't exist yet, so Doctrine throws:

```
DriverManager::getConnection(): Argument #1 (\$params) must be of type array, null given
```

This is the first and only output from the CLI and the whole E2E job fails before a single test runs.

## Impact

Every PR-triggered E2E run in `netresearch/t3x-nr-passkeys-be` since TYPO3 14.2 was released has been red on this exact error. Sample run: [t3x-nr-passkeys-be #50 E2E log](https://github.com/netresearch/t3x-nr-passkeys-be/actions/runs/24777053687/job/72497925053). Any consumer of this reusable workflow that ends up with \`typo3/cms-core: v14.2.0\` will hit the same wall.

## Fix

Write a minimal \`config/system/settings.php\` with a valid DB connection stanza **before** invoking \`typo3 setup --force\`. The setup command overwrites the file with the real installation config, so the workaround is invisible to downstream consumers. No input/interface change; no new inputs.

## Notes

The root cause is a TYPO3 core boot-order bug that should also be reported upstream, but fixing it here unblocks every consumer of this reusable workflow immediately.

## Test plan

- [x] PHP syntax of the HEREDOC validated locally
- [ ] Once merged to \`main\`, retry the failing E2E on \`netresearch/t3x-nr-passkeys-be#50\` to confirm the fix