### PR TITLE
fix(e2e): install typo3/cms-install on demand

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,6 +101,26 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-progress
 
+      - name: Ensure typo3/cms-install is available
+        # `bin/typo3 setup` (used by the next step) is provided by
+        # typo3/cms-install. Many extensions don't declare it as a dev
+        # dependency, so install it on-demand if missing. Match the major
+        # version to whatever typo3/cms-core resolved to.
+        run: |
+          if [[ -d .Build/vendor/typo3/cms-install ]]; then
+            echo "typo3/cms-install already present."
+            exit 0
+          fi
+          CORE_VERSION=$(composer show typo3/cms-core 2>/dev/null | awk '/^versions/ {print $NF}')
+          if [[ -z "$CORE_VERSION" ]]; then
+            echo "::warning::Could not detect typo3/cms-core version, falling back to ^14.0"
+            CORE_VERSION='^14.0'
+          fi
+          # Extract the major.minor constraint (e.g. v14.2.0 -> ^14.0)
+          MAJOR=$(echo "$CORE_VERSION" | sed -E 's/^v?([0-9]+)\..*/\1/')
+          composer require --dev --no-progress --no-interaction \
+            "typo3/cms-install:^${MAJOR}.0"
+
       - name: Setup TYPO3
         run: |
           # Wait for database


### PR DESCRIPTION
## Summary

`bin/typo3 setup` is provided by `typo3/cms-install`. Many extensions don't declare `cms-install` as a dev dependency because it isn't needed for their own test suites, so the reusable E2E workflow currently fails with:

```
Command \"setup\" is not defined.
Did you mean this?
    extension:setup
```

on any project that only requires `typo3/cms-core`. Install `typo3/cms-install` at workflow runtime if it isn't already present, matching the major version to whatever `typo3/cms-core` resolved to.

## How this surfaced

Follow-up to #60 (v14.2 Messenger boot-order fix). That fix unblocked CLI bootstrap far enough to run `bin/typo3 setup` and expose this second, orthogonal problem. Together the two changes make the E2E workflow run end-to-end on projects that only require `typo3/cms-core`.

## Behaviour

- `cms-install` already present → skip, no-op
- `cms-install` missing → `composer require --dev typo3/cms-install:^\${MAJOR}.0` based on detected `cms-core` version
- `cms-core` version undetectable → fallback to `^14.0` with a warning

No workflow inputs/interfaces change. No-op for consumers that already have the dep.

## Test plan

- [ ] After merge, fresh E2E run on `netresearch/t3x-nr-passkeys-be#50` should proceed past `typo3 setup` into actual Playwright tests