### PR TITLE
fix(e2e): handle projects without committed npm lock file

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -203,14 +203,39 @@ jobs:
 
           .Build/bin/typo3 cache:flush
 
-      - name: Setup Node.js
+      - name: Detect npm lock file
+        id: npm-lockfile
+        # TYPO3 extensions frequently gitignore package-lock.json, but
+        # actions/setup-node with cache='npm' and `npm ci` both require it.
+        # Skip the cache and fall back to `npm install` when no lock file
+        # is committed, otherwise keep the fast path.
+        run: |
+          if [[ -f package-lock.json ]] || [[ -f npm-shrinkwrap.json ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node.js (with npm cache)
+        if: steps.npm-lockfile.outputs.present == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
 
+      - name: Setup Node.js (no cache)
+        if: steps.npm-lockfile.outputs.present != 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
+
       - name: Install npm dependencies
-        run: npm ci
+        run: |
+          if [[ "${{ steps.npm-lockfile.outputs.present }}" == "true" ]]; then
+            npm ci
+          else
+            npm install --no-audit --no-fund
+          fi
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps ${{ inputs.playwright-browser }}


### PR DESCRIPTION
## Summary

TYPO3 extensions frequently gitignore \`package-lock.json\`. The previous setup-node step hardcoded \`cache: 'npm'\` and the next step ran \`npm ci\` — both of which require a lock file. The workflow therefore failed with:

\`\`\`
Dependencies lock file is not found in /home/runner/work/.../...
Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock
\`\`\`

on any consumer that does not commit one.

## Fix

Detect lock-file presence up front and branch:

- **lock file present** → setup-node with \`cache: 'npm'\` + \`npm ci\` (fast path)
- **lock file absent** → setup-node with no cache + \`npm install --no-audit --no-fund\`

No workflow inputs change, no consumer-visible behaviour change for projects that already commit a lock file. Projects that don't commit one now succeed instead of failing the step.

## Context

Third and (hopefully) final fix needed to make the reusable E2E workflow run end-to-end on \`netresearch/t3x-nr-passkeys-be\`. Previous commits unblocked CLI bootstrap (#60) and added missing \`cms-install\` (#61); this one clears the Node install step.

## Test plan

- [ ] After merge, fresh E2E run on \`netresearch/t3x-nr-passkeys-be#50\` should proceed past Node install into Playwright