### PR TITLE
chore(docs): bump render-guides image to 0.37.1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,8 +27,8 @@ on:
 permissions: {}
 
 env:
-  # typo3-documentation/render-guides 0.37.0
-  RENDER_GUIDES_IMAGE: ghcr.io/typo3-documentation/render-guides@sha256:431ac2644f0230c5e22174ec9d5f95c2271b038193765c3851bfdc2ad9e8cde5
+  # typo3-documentation/render-guides 0.37.1
+  RENDER_GUIDES_IMAGE: ghcr.io/typo3-documentation/render-guides@sha256:2281eeae9bf0b8f490d9be6c8d6a3b64ccb7e178f8dd14a390fc92997524f0c5
 
 jobs:
   render:


### PR DESCRIPTION
## Summary

Bumps the pinned `render-guides` image to **0.37.1** and corrects a stale/mislabelled pin.

| | Before | After |
|---|---|---|
| Comment | `# typo3-documentation/render-guides 0.37.0` | `# typo3-documentation/render-guides 0.37.1` |
| Digest | `sha256:431ac264…` (built **2026-01-18**) | `sha256:2281eeae9bf0b8f490d9be6c8d6a3b64ccb7e178f8dd14a390fc92997524f0c5` (built 2026-03-27) |
| `league/flysystem` | 1.1.10 (EOL) | 3.32.0 |

## The stale-pin story

The previous pin's comment said **0.37.0** but the digest was built on **2026-01-18** — a full two months before the `0.37.0` git tag existed (2026-03-20). Whoever added the pin captured `:latest` or `:main` at the time, not a resolved `:0.37.0` image.

Even more: **no `:0.37.0` Docker image exists on ghcr.io**. Published tags on the registry jump from `0.36.0` straight to `0.37.1`. The reason: the 0.37.0 release's Docker-publish workflow was missing write permission. [TYPO3-Documentation/render-guides#1211](https://github.com/TYPO3-Documentation/render-guides/pull/1211) ("Update docker.yaml - add permissions") fixed it in 0.37.1.

## Why this matters

The old pinned digest still ships `league/flysystem` v1, whose `Local` adapter throws `NotSupportedException` on any symbolic link encountered during `listContents()` — aborting the entire render, with no way to pre-exclude via `--exclude-path`.

The upstream Flysystem v1 → v3 upgrade is [TYPO3-Documentation/render-guides#1186](https://github.com/TYPO3-Documentation/render-guides/pull/1186) (merged 2026-03-01). The source fix is present from `0.37.0` onward; the first **image** carrying it is `0.37.1`.

## Concrete failure this fixes

- Repo: `netresearch/t3x-nr-llm`
- Failing run: https://github.com/netresearch/t3x-nr-llm/actions/runs/24824959021/job/72658428311
- PR that triggered it: https://github.com/netresearch/t3x-nr-llm/pull/136

## Verification

```bash
$ docker pull ghcr.io/typo3-documentation/render-guides:0.37.1
$ docker inspect ghcr.io/typo3-documentation/render-guides:0.37.1 \
    --format '{{index .RepoDigests 0}}'
ghcr.io/typo3-documentation/render-guides@sha256:2281eeae9bf0b8f490d9be6c8d6a3b64ccb7e178f8dd14a390fc92997524f0c5

$ docker run --rm --entrypoint sh \
    ghcr.io/typo3-documentation/render-guides:0.37.1 \
    -c "grep -A1 'league/flysystem\"' /opt/guides/composer.lock | head -2"
            "name": "league/flysystem",
            "version": "3.32.0",
```

## Test plan
- [ ] Self-CI passes on this workflow repo
- [ ] Downstream docs workflow (e.g. `nr-llm`) renders `Documentation/` successfully with symlinks present