### PR TITLE
chore(renovate): track container image pins inside workflow env vars

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,12 +6,12 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track container image pins embedded in workflow env variables (e.g. RENDER_GUIDES_IMAGE). The built-in github-actions manager only parses `uses:` refs; digests inside `env:` would otherwise rot unnoticed.",
+      "description": "Track container image pins embedded in workflow env variables (e.g. RENDER_GUIDES_IMAGE). The built-in github-actions manager only parses `uses:` refs; digests inside `env:` would otherwise rot unnoticed. The regex handles optional registry ports (registry.example.com:5000/...) and optional image tags before the digest (image:tag@sha256:...).",
       "fileMatch": [
         "^\\.github/workflows/[^/]+\\.ya?ml$"
       ],
       "matchStrings": [
-        "#\\s*(?<depName>\\S+)\\s+(?<currentValue>\\S+)\\s*\\n\\s*\\S+:\\s*(?<packageName>ghcr\\.io/[^@\\s]+|docker\\.io/[^@\\s]+|[a-z0-9.-]+/[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+        "#\\s*(?<depName>\\S+)\\s+(?<currentValue>\\S+)\\s*\\n\\s*\\S+:\\s*(?<packageName>[a-z0-9.-]+(?::\\d+)?/[^@:\\s]+)(?::[^@\\s]+)?@(?<currentDigest>sha256:[a-f0-9]+)"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track container image pins embedded in workflow env variables (e.g. RENDER_GUIDES_IMAGE). The built-in github-actions manager only parses `uses:` refs; digests inside `env:` would otherwise rot unnoticed.",
+      "fileMatch": [
+        "^\\.github/workflows/[^/]+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "#\\s*(?<depName>\\S+)\\s+(?<currentValue>\\S+)\\s*\\n\\s*\\S+:\\s*(?<packageName>ghcr\\.io/[^@\\s]+|docker\\.io/[^@\\s]+|[a-z0-9.-]+/[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a Renovate `customManagers` regex entry so image digests pinned as `env:` values in workflow files are tracked going forward. Today they are invisible to both Renovate's built-in `github-actions` manager and Dependabot's `github-actions` ecosystem (both only parse `uses:` refs).

## Why this is needed

The previous `RENDER_GUIDES_IMAGE` pin rotted for three months:

```yaml
# .github/workflows/docs.yml
env:
  # typo3-documentation/render-guides 0.37.0   ← comment claimed 0.37.0
  RENDER_GUIDES_IMAGE: ghcr.io/typo3-documentation/render-guides@sha256:431ac264…
  # ↑ digest was built 2026-01-18, predates the 0.37.0 git tag by two months
```

[PR #63](https://github.com/netresearch/typo3-ci-workflows/pull/63) fixed the immediate rot. This PR stops it happening again.

## What changed

```diff
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": [
+        "#\\s*(?<depName>\\S+)\\s+(?<currentValue>\\S+)\\s*\\n\\s*\\S+:\\s*(?<packageName>ghcr\\.io/[^@\\s]+|docker\\.io/[^@\\s]+|[a-z0-9.-]+/[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ]
 }
```

### Extraction contract

For every matching env-var pin, Renovate will extract:

| Group | From | Example |
|---|---|---|
| `depName` | comment | `typo3-documentation/render-guides` |
| `currentValue` | comment | `0.37.1` |
| `packageName` | env value | `ghcr.io/typo3-documentation/render-guides` |
| `currentDigest` | env value | `sha256:2281eeae...` |

Renovate queries the Docker datasource with `packageName`, and updates both the comment version and the digest in lockstep when a new release ships.

## Verification

Tested against the current (post-#63) `docs.yml`:

```
$ python3 -c "import re, pathlib; \
  p = r'#\s*(?P<depName>\S+)\s+(?P<currentValue>\S+)\s*\n\s*\S+:\s*(?P<packageName>ghcr\.io/[^@\s]+|docker\.io/[^@\s]+|[a-z0-9.-]+/[^@\s]+)@(?P<currentDigest>sha256:[a-f0-9]+)'; \
  m = re.search(p, pathlib.Path('.github/workflows/docs.yml').read_text()); \
  print(m.groupdict())"
{'depName': 'typo3-documentation/render-guides',
 'currentValue': '0.37.1',
 'packageName': 'ghcr.io/typo3-documentation/render-guides',
 'currentDigest': 'sha256:2281eeae9bf0b8f490d9be6c8d6a3b64ccb7e178f8dd14a390fc92997524f0c5'}
```

## Scope / non-goals

- Only matches pins that carry the `# <package> <version>` comment convention. Unlabelled digests are still invisible — by design, since Renovate needs `packageName` to query the datasource.
- Matches `ghcr.io/...`, `docker.io/...`, and any `<registry>/<path>` form. Tighten the alternation later if it false-positives on unrelated strings (none observed in this repo's workflows).

## Test plan
- [ ] Self-CI green
- [ ] Renovate dashboard picks up `RENDER_GUIDES_IMAGE` as a tracked dep on next run
- [ ] When render-guides 0.37.2 ships, Renovate opens a PR updating both the comment and the digest