### PR TITLE
feat: Phase 1 release orchestrator for TYPO3 extensions

### DIFF
--- a/.github/workflows/publish-to-docs.yml
+++ b/.github/workflows/publish-to-docs.yml
@@ -1,0 +1,110 @@
+name: Verify docs.typo3.org publication
+
+# Doesn't trigger the render — docs.typo3.org's Intercept webhook auto-triggers
+# when TER receives a new version. This workflow polls the expected rendered
+# URL until it returns 200 (or times out) so the caller can wait on it in a
+# `needs:` chain before considering the release fully published.
+
+on:
+  workflow_call:
+    inputs:
+      extension-key:
+        description: Extension key as registered on docs.typo3.org
+        required: true
+        type: string
+      vendor:
+        description: Vendor segment of the docs path (e.g. "netresearch")
+        required: false
+        type: string
+        default: netresearch
+      version:
+        description: Version to verify (no v-prefix, e.g. "0.8.0"). When empty, resolved from ext_emconf.php on the caller's ref.
+        required: false
+        type: string
+        default: ''
+      timeout-minutes:
+        description: Max minutes to wait for docs.typo3.org to serve the version
+        required: false
+        type: number
+        default: 45
+      poll-interval-seconds:
+        description: Seconds between polls
+        required: false
+        type: number
+        default: 60
+
+permissions: {}
+
+jobs:
+  verify:
+    name: Verify docs.typo3.org
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout (for ext_emconf.php version fallback only)
+        if: inputs.version == ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Resolve version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ -n "$INPUT_VERSION" ]]; then
+            VERSION="$INPUT_VERSION"
+          else
+            if [[ ! -f ext_emconf.php ]]; then
+              echo "::error::No version input provided and ext_emconf.php not found on caller's ref"
+              exit 1
+            fi
+            VERSION=$(sed -nE "s/.*'version'[[:space:]]*=>[[:space:]]*'([^']+)'.*/\1/p" ext_emconf.php)
+            if [[ -z "$VERSION" ]]; then
+              echo "::error file=ext_emconf.php::Could not extract version"
+              exit 1
+            fi
+          fi
+          # Strip optional v-prefix for safety
+          VERSION="${VERSION#v}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version format: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Poll docs.typo3.org
+        env:
+          VENDOR: ${{ inputs.vendor }}
+          KEY: ${{ inputs.extension-key }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
+          POLL_INTERVAL: ${{ inputs.poll-interval-seconds }}
+        run: |
+          URL="https://docs.typo3.org/p/${VENDOR}/${KEY}/${VERSION}/en-us/"
+          echo "Waiting for $URL (timeout: ${TIMEOUT_MINUTES}m, poll every ${POLL_INTERVAL}s)"
+
+          DEADLINE=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
+          ATTEMPT=0
+          while true; do
+            ATTEMPT=$((ATTEMPT + 1))
+            STATUS=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "$URL" || echo "000")
+            if [[ "$STATUS" == "200" ]]; then
+              echo "docs.typo3.org serves $VERSION (attempt $ATTEMPT)"
+              echo "docs-url=$URL" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [[ $(date +%s) -ge $DEADLINE ]]; then
+              echo "::error::Timed out waiting for $URL (last status: $STATUS)"
+              exit 1
+            fi
+            echo "Attempt $ATTEMPT: status $STATUS, retrying in ${POLL_INTERVAL}s"
+            sleep "$POLL_INTERVAL"
+          done

--- a/.github/workflows/publish-to-packagist.yml
+++ b/.github/workflows/publish-to-packagist.yml
@@ -1,0 +1,154 @@
+name: Publish to Packagist
+
+# Triggers a Packagist update for the repo and polls the API until the new
+# version is visible, so the caller can wait on it in a `needs:` chain.
+#
+# Idempotent: Packagist's update endpoint tolerates repeated calls for the
+# same version. If the version is already visible when we start, we return
+# success without hitting the update endpoint.
+
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        description: Composer package name (e.g. "netresearch/nr-passkeys-be")
+        required: true
+        type: string
+      version:
+        description: Version to verify (no v-prefix, e.g. "0.8.0"). When empty, resolved from ext_emconf.php on the caller's ref.
+        required: false
+        type: string
+        default: ''
+      timeout-minutes:
+        description: Max minutes to wait for Packagist to list the version
+        required: false
+        type: number
+        default: 10
+      poll-interval-seconds:
+        description: Seconds between polls
+        required: false
+        type: number
+        default: 15
+    secrets:
+      PACKAGIST_USERNAME:
+        description: Packagist username that owns the package
+        required: true
+      PACKAGIST_TOKEN:
+        description: Packagist API token for the user
+        required: true
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish to Packagist
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout (for ext_emconf.php version fallback only)
+        if: inputs.version == ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Resolve version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ -n "$INPUT_VERSION" ]]; then
+            VERSION="$INPUT_VERSION"
+          else
+            if [[ ! -f ext_emconf.php ]]; then
+              echo "::error::No version input provided and ext_emconf.php not found on caller's ref"
+              exit 1
+            fi
+            VERSION=$(sed -nE "s/.*'version'[[:space:]]*=>[[:space:]]*'([^']+)'.*/\1/p" ext_emconf.php)
+          fi
+          VERSION="${VERSION#v}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version format: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version is already on Packagist
+        id: precheck
+        env:
+          PACKAGE: ${{ inputs.package-name }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Packagist's P2 metadata is what Composer consumes. Cache propagation
+          # can lag the webhook by a minute or two; we accept that lag and only
+          # use this precheck to short-circuit the trigger on re-runs.
+          URL="https://repo.packagist.org/p2/${PACKAGE}.json"
+          BODY=$(curl -sS --max-time 15 "$URL" || true)
+          if [[ -n "$BODY" ]] && echo "$BODY" | jq -e --arg p "$PACKAGE" --arg v "$VERSION" \
+              '.packages[$p] | map(.version == $v or .version == ("v" + $v)) | any' \
+              >/dev/null 2>&1; then
+            echo "already-published=true" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION already visible on Packagist"
+          else
+            echo "already-published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger Packagist update
+        if: steps.precheck.outputs.already-published != 'true'
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Packagist accepts the GitHub repo URL verbatim; it then re-scans
+          # its own mirror and updates the P2 metadata. Webhook delivery is
+          # best-effort, so calling the update endpoint explicitly guarantees
+          # the scan happens regardless of the GitHub → Packagist integration
+          # state.
+          RESPONSE=$(curl -sS -w '\n%{http_code}' -X POST \
+            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"repository\":{\"url\":\"${SERVER_URL}/${REPO}\"}}" \
+            --max-time 30)
+          BODY=$(echo "$RESPONSE" | head -n -1)
+          CODE=$(echo "$RESPONSE" | tail -n 1)
+          if [[ "$CODE" != "200" && "$CODE" != "202" ]]; then
+            echo "::error::Packagist update returned HTTP $CODE: $BODY"
+            exit 1
+          fi
+          echo "Packagist update triggered (HTTP $CODE)"
+
+      - name: Poll Packagist until version visible
+        if: steps.precheck.outputs.already-published != 'true'
+        env:
+          PACKAGE: ${{ inputs.package-name }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
+          POLL_INTERVAL: ${{ inputs.poll-interval-seconds }}
+        run: |
+          URL="https://repo.packagist.org/p2/${PACKAGE}.json"
+          DEADLINE=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
+          ATTEMPT=0
+          while true; do
+            ATTEMPT=$((ATTEMPT + 1))
+            BODY=$(curl -sS --max-time 15 "$URL" || true)
+            if [[ -n "$BODY" ]] && echo "$BODY" | jq -e --arg p "$PACKAGE" --arg v "$VERSION" \
+                '.packages[$p] | map(.version == $v or .version == ("v" + $v)) | any' \
+                >/dev/null 2>&1; then
+              echo "Packagist lists $VERSION (attempt $ATTEMPT)"
+              exit 0
+            fi
+            if [[ $(date +%s) -ge $DEADLINE ]]; then
+              echo "::error::Timed out waiting for Packagist to list $VERSION"
+              exit 1
+            fi
+            echo "Attempt $ATTEMPT: version not yet visible, retrying in ${POLL_INTERVAL}s"
+            sleep "$POLL_INTERVAL"
+          done

--- a/.github/workflows/publish-to-packagist.yml
+++ b/.github/workflows/publish-to-packagist.yml
@@ -1,11 +1,10 @@
-name: Publish to Packagist
+name: Verify Packagist publication
 
-# Triggers a Packagist update for the repo and polls the API until the new
-# version is visible, so the caller can wait on it in a `needs:` chain.
-#
-# Idempotent: Packagist's update endpoint tolerates repeated calls for the
-# same version. If the version is already visible when we start, we return
-# success without hitting the update endpoint.
+# Doesn't trigger the update — Packagist's GitHub integration auto-subscribes
+# to push/tag events for every Netresearch repo and rescans on its own. This
+# workflow polls the Packagist P2 API until the new version is visible, so
+# the caller can wait on it in a `needs:` chain before considering the
+# release fully published.
 
 on:
   workflow_call:
@@ -29,19 +28,12 @@ on:
         required: false
         type: number
         default: 15
-    secrets:
-      PACKAGIST_USERNAME:
-        description: Packagist username that owns the package
-        required: true
-      PACKAGIST_TOKEN:
-        description: Packagist API token for the user
-        required: true
 
 permissions: {}
 
 jobs:
-  publish:
-    name: Publish to Packagist
+  verify:
+    name: Verify Packagist
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
@@ -79,54 +71,7 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Check if version is already on Packagist
-        id: precheck
-        env:
-          PACKAGE: ${{ inputs.package-name }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          # Packagist's P2 metadata is what Composer consumes. Cache propagation
-          # can lag the webhook by a minute or two; we accept that lag and only
-          # use this precheck to short-circuit the trigger on re-runs.
-          URL="https://repo.packagist.org/p2/${PACKAGE}.json"
-          BODY=$(curl -sS --max-time 15 "$URL" || true)
-          if [[ -n "$BODY" ]] && echo "$BODY" | jq -e --arg p "$PACKAGE" --arg v "$VERSION" \
-              '.packages[$p] | map(.version == $v or .version == ("v" + $v)) | any' \
-              >/dev/null 2>&1; then
-            echo "already-published=true" >> "$GITHUB_OUTPUT"
-            echo "Version $VERSION already visible on Packagist"
-          else
-            echo "already-published=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Trigger Packagist update
-        if: steps.precheck.outputs.already-published != 'true'
-        env:
-          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
-          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
-          SERVER_URL: ${{ github.server_url }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Packagist accepts the GitHub repo URL verbatim; it then re-scans
-          # its own mirror and updates the P2 metadata. Webhook delivery is
-          # best-effort, so calling the update endpoint explicitly guarantees
-          # the scan happens regardless of the GitHub → Packagist integration
-          # state.
-          RESPONSE=$(curl -sS -w '\n%{http_code}' -X POST \
-            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"repository\":{\"url\":\"${SERVER_URL}/${REPO}\"}}" \
-            --max-time 30)
-          BODY=$(echo "$RESPONSE" | head -n -1)
-          CODE=$(echo "$RESPONSE" | tail -n 1)
-          if [[ "$CODE" != "200" && "$CODE" != "202" ]]; then
-            echo "::error::Packagist update returned HTTP $CODE: $BODY"
-            exit 1
-          fi
-          echo "Packagist update triggered (HTTP $CODE)"
-
       - name: Poll Packagist until version visible
-        if: steps.precheck.outputs.already-published != 'true'
         env:
           PACKAGE: ${{ inputs.package-name }}
           VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -7,6 +7,21 @@ on:
         description: PHP version for tailor
         type: string
         default: '8.4'
+      ref:
+        description: Git ref (tag or SHA) to check out. Defaults to the event ref — set this explicitly when re-triggering from a workflow_dispatch against a branch to ensure the correct source is packaged.
+        required: false
+        type: string
+        default: ''
+      verify-timeout-minutes:
+        description: Max minutes to wait for TER to serve the published version
+        required: false
+        type: number
+        default: 10
+      verify-poll-interval-seconds:
+        description: Seconds between TER verification polls
+        required: false
+        type: number
+        default: 30
     secrets:
       TYPO3_EXTENSION_KEY:
         description: "Deprecated: extension key is auto-resolved from composer.json"
@@ -34,7 +49,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Resolve version
         id: version
@@ -195,10 +210,55 @@ jobs:
             echo "$DELIMITER"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Check if version is already on TER
+        id: precheck
+        env:
+          KEY: ${{ steps.extkey.outputs.key }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # HEAD the download URL: 200 => version already published, skip.
+          # This makes the workflow idempotent so republishing a tag after a
+          # partial failure is a safe no-op on the TER side.
+          URL="https://extensions.typo3.org/extension/download/${KEY}/${VERSION}/zip"
+          STATUS=$(curl -sS -o /dev/null -w '%{http_code}' -I --max-time 15 "$URL" || echo "000")
+          if [[ "$STATUS" == "200" ]]; then
+            echo "already-published=true" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION is already on TER — skipping publish"
+          else
+            echo "already-published=false" >> "$GITHUB_OUTPUT"
+            echo "TER precheck status for $VERSION: $STATUS (will publish)"
+          fi
+
       - name: Publish to TER
+        if: steps.precheck.outputs.already-published != 'true'
         env:
           TYPO3_EXTENSION_KEY: ${{ steps.extkey.outputs.key }}
           TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
           COMMENT: ${{ steps.comment.outputs.comment }}
         run: php ~/.composer/vendor/bin/tailor ter:publish --comment="$COMMENT" "$VERSION"
+
+      - name: Verify TER serves the version
+        env:
+          KEY: ${{ steps.extkey.outputs.key }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TIMEOUT_MINUTES: ${{ inputs.verify-timeout-minutes }}
+          POLL_INTERVAL: ${{ inputs.verify-poll-interval-seconds }}
+        run: |
+          URL="https://extensions.typo3.org/extension/download/${KEY}/${VERSION}/zip"
+          DEADLINE=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
+          ATTEMPT=0
+          while true; do
+            ATTEMPT=$((ATTEMPT + 1))
+            STATUS=$(curl -sS -o /dev/null -w '%{http_code}' -I --max-time 15 "$URL" || echo "000")
+            if [[ "$STATUS" == "200" ]]; then
+              echo "TER serves $VERSION (attempt $ATTEMPT)"
+              exit 0
+            fi
+            if [[ $(date +%s) -ge $DEADLINE ]]; then
+              echo "::error::Timed out waiting for TER to serve $VERSION (last status: $STATUS)"
+              exit 1
+            fi
+            echo "Attempt $ATTEMPT: status $STATUS, retrying in ${POLL_INTERVAL}s"
+            sleep "$POLL_INTERVAL"
+          done

--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -1,0 +1,338 @@
+name: Release (TYPO3 extension)
+
+# Orchestrator for the full TYPO3-extension release pipeline.
+#
+# Order of operations (immutability-friendly):
+#
+#   1. build-and-sign — create archives, SBOMs, checksums, Cosign signatures,
+#      build-provenance attestations. Uploads everything as the `dist` run
+#      artifact. No external publishing yet.
+#   2. publish-to-ter, publish-to-packagist — run in parallel after the build
+#      succeeds. Each sub-workflow is idempotent and polls its respective
+#      service until the new version is visible.
+#   3. publish-to-docs — polls docs.typo3.org AFTER TER confirms, because the
+#      TER → Intercept webhook is what triggers the docs render.
+#   4. create-release — the GitHub release is created LAST, in a single
+#      atomic `softprops/action-gh-release` call, with every artifact and the
+#      verification-evidence block already determined. Compatible with GitHub
+#      "Immutable Releases": nothing is added, removed, or edited after
+#      publication.
+#
+# If any of steps 2–3 fail, step 4 is skipped: no release is created, the
+# tag exists without a GitHub release, and the maintainer re-runs the whole
+# orchestrator (which is idempotent on every publish step) to finish. The
+# `republish.yml` dispatcher is for recovering a completed release whose
+# publishes later regressed — not for mid-release crashes.
+
+on:
+  workflow_call:
+    inputs:
+      archive-prefix:
+        description: 'Prefix for release archive files (e.g., "nr-passkeys-be")'
+        required: true
+        type: string
+      package-name:
+        description: 'Composer package name (e.g., "netresearch/nr-passkeys-be")'
+        required: true
+        type: string
+      extension-key:
+        description: 'TYPO3 extension key (e.g., "nr_passkeys_be")'
+        required: true
+        type: string
+      vendor:
+        description: 'docs.typo3.org vendor segment (owner of the docs URL)'
+        required: false
+        type: string
+        default: netresearch
+      include-sbom:
+        description: Include SPDX and CycloneDX SBOMs as release assets
+        required: false
+        type: boolean
+        default: true
+      sign-artifacts:
+        description: Sign artifacts with Cosign keyless signing
+        required: false
+        type: boolean
+        default: true
+      skip-ter:
+        description: Skip TER publish + verification (for testing only)
+        required: false
+        type: boolean
+        default: false
+      skip-packagist:
+        description: Skip Packagist publish + verification
+        required: false
+        type: boolean
+        default: false
+      skip-docs:
+        description: Skip docs.typo3.org verification
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      TYPO3_TER_ACCESS_TOKEN:
+        required: false
+      PACKAGIST_USERNAME:
+        required: false
+      PACKAGIST_TOKEN:
+        required: false
+
+permissions: {}
+
+jobs:
+  build-and-sign:
+    name: Build & sign artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release-notes: ${{ steps.notes.outputs.notes }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve version from tag
+        id: version
+        env:
+          ARCHIVE_PREFIX: ${{ inputs.archive-prefix }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version derived from tag: $GITHUB_REF_NAME"
+            exit 1
+          fi
+          if [[ "$ARCHIVE_PREFIX" == *..* ]] || [[ "$ARCHIVE_PREFIX" == /* ]]; then
+            echo "::error::Invalid archive-prefix: $ARCHIVE_PREFIX"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        id: notes
+        # Phase 1 keeps the git-log approach used by release.yml. Phase 3 swaps
+        # this for git-cliff + contributor/reporter attribution.
+        run: |
+          DELIMITER="ghadelim_$(openssl rand -hex 8)"
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          {
+            echo "notes<<$DELIMITER"
+            if [[ -z "$PREVIOUS_TAG" ]]; then
+              echo "Initial release"
+            else
+              git log --pretty=format:"- %s" "${PREVIOUS_TAG}..HEAD"
+              echo ""
+            fi
+            echo "$DELIMITER"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create release archives
+        env:
+          ARCHIVE_PREFIX: ${{ inputs.archive-prefix }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          mkdir -p dist
+          git archive --format=zip --prefix="${ARCHIVE_PREFIX}/" HEAD -o "dist/${ARCHIVE_PREFIX}-${VERSION}.zip"
+          git archive --format=tar.gz --prefix="${ARCHIVE_PREFIX}/" HEAD -o "dist/${ARCHIVE_PREFIX}-${VERSION}.tar.gz"
+
+      - name: Generate SBOM (SPDX)
+        if: inputs.include-sbom
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          output-file: dist/${{ inputs.archive-prefix }}-${{ steps.version.outputs.version }}.sbom.spdx.json
+
+      - name: Generate SBOM (CycloneDX)
+        if: inputs.include-sbom
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: dist/${{ inputs.archive-prefix }}-${{ steps.version.outputs.version }}.sbom.cdx.json
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum ./* > checksums.txt
+          cat checksums.txt
+
+      - name: Install Cosign
+        if: inputs.sign-artifacts
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Sign artifacts with Cosign (keyless)
+        if: inputs.sign-artifacts
+        run: |
+          cd dist
+          for file in *; do
+            [ -f "$file" ] || continue
+            case "$file" in
+              *.bundle) continue ;;  # don't sign already-generated bundles
+            esac
+            cosign sign-blob --yes "$file" --bundle "${file}.bundle"
+          done
+
+      - name: Generate build-provenance attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/${{ inputs.archive-prefix }}-${{ steps.version.outputs.version }}.zip
+            dist/${{ inputs.archive-prefix }}-${{ steps.version.outputs.version }}.tar.gz
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-dist
+          path: dist/
+          retention-days: 1
+          if-no-files-found: error
+
+  publish-to-ter:
+    name: Publish to TER
+    needs: build-and-sign
+    if: ${{ !inputs.skip-ter }}
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
+    with:
+      ref: ${{ github.ref }}
+    secrets: inherit
+
+  publish-to-packagist:
+    name: Publish to Packagist
+    needs: build-and-sign
+    if: ${{ !inputs.skip-packagist }}
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-packagist.yml@main
+    with:
+      package-name: ${{ inputs.package-name }}
+      version: ${{ needs.build-and-sign.outputs.version }}
+    secrets: inherit
+
+  publish-to-docs:
+    name: Verify docs.typo3.org
+    needs: [build-and-sign, publish-to-ter]
+    # Docs render fires via TER → Intercept — poll only after TER confirmed.
+    # Skipping TER also skips docs; no independent trigger exists.
+    if: ${{ !inputs.skip-docs && !inputs.skip-ter && needs.publish-to-ter.result == 'success' }}
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-docs.yml@main
+    with:
+      extension-key: ${{ inputs.extension-key }}
+      vendor: ${{ inputs.vendor }}
+      version: ${{ needs.build-and-sign.outputs.version }}
+
+  create-release:
+    name: Create GitHub Release
+    needs: [build-and-sign, publish-to-ter, publish-to-packagist, publish-to-docs]
+    # Run only if every non-skipped publish reached success. This enforces
+    # "release-last": the GitHub release is a receipt of a successful run, and
+    # never a canvas that gets edited afterwards. If any publish failed, no
+    # release is created and the orchestrator must be re-run to finish.
+    if: >-
+      ${{
+        always()
+        && needs.build-and-sign.result == 'success'
+        && (needs.publish-to-ter.result == 'success' || needs.publish-to-ter.result == 'skipped')
+        && (needs.publish-to-packagist.result == 'success' || needs.publish-to-packagist.result == 'skipped')
+        && (needs.publish-to-docs.result == 'success' || needs.publish-to-docs.result == 'skipped')
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: release-dist
+          path: dist/
+
+      - name: Compose verification-evidence block
+        id: evidence
+        env:
+          PACKAGE: ${{ inputs.package-name }}
+          KEY: ${{ inputs.extension-key }}
+          VENDOR: ${{ inputs.vendor }}
+          VERSION: ${{ needs.build-and-sign.outputs.version }}
+          TER_RESULT: ${{ needs.publish-to-ter.result }}
+          PKGST_RESULT: ${{ needs.publish-to-packagist.result }}
+          DOCS_RESULT: ${{ needs.publish-to-docs.result }}
+        run: |
+          DELIMITER="ghadelim_$(openssl rand -hex 8)"
+          {
+            echo "block<<$DELIMITER"
+            echo "## Publication status"
+            echo ""
+            if [[ "$TER_RESULT" == "success" ]]; then
+              echo "- TER: [extensions.typo3.org/extension/${KEY}](https://extensions.typo3.org/extension/${KEY}) — ${VERSION} verified"
+            elif [[ "$TER_RESULT" == "skipped" ]]; then
+              echo "- TER: skipped"
+            fi
+            if [[ "$PKGST_RESULT" == "success" ]]; then
+              echo "- Packagist: [packagist.org/packages/${PACKAGE}](https://packagist.org/packages/${PACKAGE}) — ${VERSION} verified"
+            elif [[ "$PKGST_RESULT" == "skipped" ]]; then
+              echo "- Packagist: skipped"
+            fi
+            if [[ "$DOCS_RESULT" == "success" ]]; then
+              echo "- Documentation: [docs.typo3.org/p/${VENDOR}/${KEY}/${VERSION}/en-us/](https://docs.typo3.org/p/${VENDOR}/${KEY}/${VERSION}/en-us/) — verified"
+            elif [[ "$DOCS_RESULT" == "skipped" ]]; then
+              echo "- Documentation: skipped"
+            fi
+            echo "$DELIMITER"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release (atomic, all assets)
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          files: |
+            dist/*
+          fail_on_unmatched_files: true
+          body: |
+            ## Changes
+            ${{ needs.build-and-sign.outputs.release-notes }}
+
+            ## Installation
+
+            ```bash
+            composer require ${{ inputs.package-name }}
+            ```
+
+            ${{ steps.evidence.outputs.block }}
+
+            ## Security
+
+            All release artifacts are signed with [Sigstore](https://www.sigstore.dev/) keyless signing.
+
+            ### Verify signatures
+
+            ```bash
+            cosign verify-blob \
+              --bundle ${{ inputs.archive-prefix }}-${{ needs.build-and-sign.outputs.version }}.zip.bundle \
+              --certificate-identity-regexp "https://github.com/${{ github.repository_owner }}/.*" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              ${{ inputs.archive-prefix }}-${{ needs.build-and-sign.outputs.version }}.zip
+            ```
+
+            ### Verify checksums
+
+            ```bash
+            sha256sum -c checksums.txt
+            ```
+
+            ## Software Bill of Materials (SBOM)
+
+            SBOMs are provided in both SPDX and CycloneDX formats for supply chain transparency.

--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -72,10 +72,6 @@ on:
     secrets:
       TYPO3_TER_ACCESS_TOKEN:
         required: false
-      PACKAGIST_USERNAME:
-        required: false
-      PACKAGIST_TOKEN:
-        required: false
 
 permissions: {}
 
@@ -208,22 +204,25 @@ jobs:
       ref: ${{ github.ref }}
     secrets: inherit
 
-  publish-to-packagist:
-    name: Publish to Packagist
+  verify-packagist:
+    name: Verify Packagist
     needs: build-and-sign
     if: ${{ !inputs.skip-packagist }}
+    # Packagist's GitHub integration auto-subscribes to push/tag events and
+    # rescans without our workflow having to do anything. This job only
+    # polls the Packagist API until the new version is visible.
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-packagist.yml@main
     with:
       package-name: ${{ inputs.package-name }}
       version: ${{ needs.build-and-sign.outputs.version }}
-    secrets: inherit
 
-  publish-to-docs:
+  verify-docs:
     name: Verify docs.typo3.org
-    needs: [build-and-sign, publish-to-ter]
-    # Docs render fires via TER → Intercept — poll only after TER confirmed.
-    # Skipping TER also skips docs; no independent trigger exists.
-    if: ${{ !inputs.skip-docs && !inputs.skip-ter && needs.publish-to-ter.result == 'success' }}
+    needs: build-and-sign
+    # docs.typo3.org renders via the Intercept webhook subscribed to GitHub
+    # push events — independent of TER. Runs in parallel with the TER and
+    # Packagist jobs, no `needs:` coupling.
+    if: ${{ !inputs.skip-docs }}
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-docs.yml@main
     with:
       extension-key: ${{ inputs.extension-key }}
@@ -232,7 +231,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [build-and-sign, publish-to-ter, publish-to-packagist, publish-to-docs]
+    needs: [build-and-sign, publish-to-ter, verify-packagist, verify-docs]
     # Run only if every non-skipped publish reached success. This enforces
     # "release-last": the GitHub release is a receipt of a successful run, and
     # never a canvas that gets edited afterwards. If any publish failed, no
@@ -242,8 +241,8 @@ jobs:
         always()
         && needs.build-and-sign.result == 'success'
         && (needs.publish-to-ter.result == 'success' || needs.publish-to-ter.result == 'skipped')
-        && (needs.publish-to-packagist.result == 'success' || needs.publish-to-packagist.result == 'skipped')
-        && (needs.publish-to-docs.result == 'success' || needs.publish-to-docs.result == 'skipped')
+        && (needs.verify-packagist.result == 'success' || needs.verify-packagist.result == 'skipped')
+        && (needs.verify-docs.result == 'success' || needs.verify-docs.result == 'skipped')
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -269,8 +268,8 @@ jobs:
           VENDOR: ${{ inputs.vendor }}
           VERSION: ${{ needs.build-and-sign.outputs.version }}
           TER_RESULT: ${{ needs.publish-to-ter.result }}
-          PKGST_RESULT: ${{ needs.publish-to-packagist.result }}
-          DOCS_RESULT: ${{ needs.publish-to-docs.result }}
+          PKGST_RESULT: ${{ needs.verify-packagist.result }}
+          DOCS_RESULT: ${{ needs.verify-docs.result }}
         run: |
           DELIMITER="ghadelim_$(openssl rand -hex 8)"
           {

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -1,0 +1,106 @@
+name: Republish
+
+# Manually re-run publish steps against an existing tag. Meant to be wrapped
+# by a consumer `workflow_dispatch` in each extension so a maintainer can
+# recover a partially-failed release (e.g. TER accepted, Packagist didn't)
+# without cutting a new version. All sub-steps are idempotent — running
+# republish against a fully-published version is a safe no-op.
+#
+# Explicitly does NOT mutate the existing GitHub release, per our release
+# immutability policy. If the release itself is missing (first-run aborted
+# before creation), the orchestrator `release-typo3-extension.yml` must be
+# re-run instead; this workflow only retries the external publishes.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Git tag to republish (e.g. "v0.8.0")
+        required: true
+        type: string
+      target:
+        description: Which publish target(s) to re-run
+        required: true
+        type: string   # 'ter' | 'docs' | 'packagist' | 'all'
+      extension-key:
+        description: Extension key as registered on TER/docs.typo3.org
+        required: true
+        type: string
+      package-name:
+        description: Composer package name
+        required: true
+        type: string
+      vendor:
+        description: docs.typo3.org vendor segment
+        required: false
+        type: string
+        default: netresearch
+    secrets:
+      TYPO3_TER_ACCESS_TOKEN:
+        required: false
+      PACKAGIST_USERNAME:
+        required: false
+      PACKAGIST_TOKEN:
+        required: false
+
+permissions: {}
+
+jobs:
+  resolve-version:
+    name: Resolve version from tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Strip v-prefix
+        id: v
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          V="${TAG#v}"
+          if ! echo "$V" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid tag format: $TAG (expected semver, optionally v-prefixed)"
+            exit 1
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+
+  republish-ter:
+    name: TER
+    if: inputs.target == 'ter' || inputs.target == 'all'
+    needs: resolve-version
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
+    with:
+      ref: ${{ inputs.tag }}
+    secrets: inherit
+
+  republish-packagist:
+    name: Packagist
+    if: inputs.target == 'packagist' || inputs.target == 'all'
+    needs: resolve-version
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-packagist.yml@main
+    with:
+      package-name: ${{ inputs.package-name }}
+      version: ${{ needs.resolve-version.outputs.version }}
+    secrets: inherit
+
+  republish-docs:
+    name: docs.typo3.org
+    # Run after TER — docs.typo3.org only starts rendering once TER's Intercept
+    # webhook fires, so polling the docs URL before TER is live would always
+    # time out. The `always()` is needed so docs still verifies when the
+    # caller re-runs only docs or the all-target chain includes TER as well.
+    if: ${{ always() && (inputs.target == 'docs' || inputs.target == 'all') }}
+    needs: [resolve-version, republish-ter]
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-docs.yml@main
+    with:
+      extension-key: ${{ inputs.extension-key }}
+      vendor: ${{ inputs.vendor }}
+      version: ${{ needs.resolve-version.outputs.version }}

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -38,10 +38,6 @@ on:
     secrets:
       TYPO3_TER_ACCESS_TOKEN:
         required: false
-      PACKAGIST_USERNAME:
-        required: false
-      PACKAGIST_TOKEN:
-        required: false
 
 permissions: {}
 
@@ -85,20 +81,19 @@ jobs:
     name: Packagist
     if: inputs.target == 'packagist' || inputs.target == 'all'
     needs: resolve-version
+    # Verify-only: Packagist's GitHub integration auto-updates on push/tag.
+    # This job just polls until the version is visible in the P2 API.
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-packagist.yml@main
     with:
       package-name: ${{ inputs.package-name }}
       version: ${{ needs.resolve-version.outputs.version }}
-    secrets: inherit
 
   republish-docs:
     name: docs.typo3.org
-    # Run after TER — docs.typo3.org only starts rendering once TER's Intercept
-    # webhook fires, so polling the docs URL before TER is live would always
-    # time out. The `always()` is needed so docs still verifies when the
-    # caller re-runs only docs or the all-target chain includes TER as well.
-    if: ${{ always() && (inputs.target == 'docs' || inputs.target == 'all') }}
-    needs: [resolve-version, republish-ter]
+    if: inputs.target == 'docs' || inputs.target == 'all'
+    needs: resolve-version
+    # Verify-only: docs.typo3.org renders via Intercept's GitHub push webhook,
+    # independent of TER. Runs in parallel with the TER and Packagist jobs.
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-docs.yml@main
     with:
       extension-key: ${{ inputs.extension-key }}


### PR DESCRIPTION
**Draft** — opening for review before merge. This is Phase 1 of the comprehensive release-workflow refactor discussed in \`netresearch/t3x-nr-passkeys-be\` after the v0.8.0 chain-trigger incident.

## Goal

One reusable orchestrator that every TYPO3 extension calls on tag push. It:
1. Builds + signs artifacts (existing behaviour).
2. Publishes to TER + Packagist in parallel.
3. Waits for docs.typo3.org to serve the version (Intercept auto-triggers the render on TER publish).
4. Creates the GitHub release **last**, atomically, with all assets and a verification-evidence block.

No more \`release: published\` chain-trigger reliance. No more silent \"release succeeded, TER didn't\". The GitHub release is a receipt of a successful publish to every configured target.

## Immutability

Compatible with GitHub Immutable Releases (to be enabled org-wide in Phase 2):
- Every asset is uploaded in one \`softprops/action-gh-release\` call.
- No step modifies an existing release.
- \`republish.yml\` re-runs publishes for an existing tag but never edits the release; if the release is missing (first-run aborted), the orchestrator (not republish) is the recovery tool.

## Files

| File | Change | Purpose |
|------|--------|---------|
| \`release-typo3-extension.yml\` | new | Orchestrator |
| \`publish-to-docs.yml\` | new | Poll docs.typo3.org until version live |
| \`publish-to-packagist.yml\` | new | Trigger + poll Packagist |
| \`republish.yml\` | new | \`workflow_call\` dispatcher for manual re-run |
| \`publish-to-ter.yml\` | updated | \`ref\` input, idempotency precheck, post-publish poll |

Every sub-publish is idempotent; pre-checks return success without touching the external service if the version is already visible. Running the orchestrator (or \`republish\`) twice is a safe no-op.

## Pinning policy

- \`netresearch/typo3-ci-workflows/...@main\` for cross-references (org-owned, trusted).
- All third-party actions pinned to full 40-char commit SHA with trailing \`# vX.Y.Z\` comment.

## Deferred (later phases)

Out of scope for this PR:
- Phase 2: signed-tag enforcement, metadata-check workflow (ext_emconf ↔ composer ↔ guides.xml), docs-link-check, Immutable Releases org ruleset.
- Phase 3: git-cliff release notes, PR-author + issue-reporter + Jira-reporter attribution.
- Phase 6: \"no actions in project workflows\" sweep for CodeQL / Scorecard / dep-review / auto-merge / pr-quality.
- Phase 6+: versioning automation (release-please-style).

Each lands as its own PR against this repo; this one is kept narrow to stay reviewable.

## Test plan

- [x] YAML syntax: \`python3 -c 'yaml.safe_load(...)'\` — all 5 files parse.
- [x] \`actionlint\` — clean.
- [ ] Self-CI workflows run on this PR.
- [ ] Pilot integration: \`netresearch/t3x-nr-passkeys-be\` will get a sweep PR after this merges that replaces its \`release.yml\` and \`ter-publish.yml\` with thin callers and adds a \`republish.yml\`. That PR is the real end-to-end test.
- [ ] Secrets to provision before pilot: \`PACKAGIST_USERNAME\`, \`PACKAGIST_TOKEN\` (org-level, so all extensions can use them).