### PR TITLE
fix(orchestrator): declare permissions on uses-jobs to avoid startup_failure

### DIFF
--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -199,6 +199,14 @@ jobs:
     name: Publish to TER
     needs: build-and-sign
     if: ${{ !inputs.skip-ter }}
+    # Declare permissions at the calling-job level so GitHub's startup-time
+    # validator sees that we can cover publish-to-ter.yml's inner
+    # `contents: read`. Without this the workflow fails with `startup_failure`
+    # and zero materialised jobs — the inner reusable's permissions cannot
+    # exceed what the caller job grants, and the workflow-level
+    # `permissions: {}` (no default) does not propagate to `uses:` jobs.
+    permissions:
+      contents: read
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
     with:
       ref: ${{ github.ref }}
@@ -211,6 +219,8 @@ jobs:
     # Packagist's GitHub integration auto-subscribes to push/tag events and
     # rescans without our workflow having to do anything. This job only
     # polls the Packagist API until the new version is visible.
+    permissions:
+      contents: read
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-packagist.yml@main
     with:
       package-name: ${{ inputs.package-name }}
@@ -223,6 +233,8 @@ jobs:
     # push events — independent of TER. Runs in parallel with the TER and
     # Packagist jobs, no `needs:` coupling.
     if: ${{ !inputs.skip-docs }}
+    permissions:
+      contents: read
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-docs.yml@main
     with:
       extension-key: ${{ inputs.extension-key }}

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -72,6 +72,8 @@ jobs:
     name: TER
     if: inputs.target == 'ter' || inputs.target == 'all'
     needs: resolve-version
+    permissions:
+      contents: read
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
     with:
       ref: ${{ inputs.tag }}
@@ -83,6 +85,8 @@ jobs:
     needs: resolve-version
     # Verify-only: Packagist's GitHub integration auto-updates on push/tag.
     # This job just polls until the version is visible in the P2 API.
+    permissions:
+      contents: read
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-packagist.yml@main
     with:
       package-name: ${{ inputs.package-name }}
@@ -94,6 +98,8 @@ jobs:
     needs: resolve-version
     # Verify-only: docs.typo3.org renders via Intercept's GitHub push webhook,
     # independent of TER. Runs in parallel with the TER and Packagist jobs.
+    permissions:
+      contents: read
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-docs.yml@main
     with:
       extension-key: ${{ inputs.extension-key }}


### PR DESCRIPTION
## Summary

First use of the new orchestrator in anger (\`netresearch/t3x-nr-passkeys-be\` v0.8.1 tag push) produced a \`startup_failure\` with zero materialised jobs. The workflow never even started.

## Root cause

Each \`uses:\` job in \`release-typo3-extension.yml\` (\`publish-to-ter\`, \`verify-packagist\`, \`verify-docs\`) had no explicit \`permissions:\` block. They inherited the workflow-level \`permissions: {}\` (no defaults). The reusable workflows they call (\`publish-to-ter.yml\`, \`publish-to-packagist.yml\`, \`publish-to-docs.yml\`) each declare \`contents: read\` on their inner jobs.

GitHub's startup-time validator rejects the chain because a \`uses:\` job cannot grant the called workflow permissions it doesn't have itself. Declaring \`permissions: contents: read\` explicitly on each \`uses:\` job satisfies the validator.

## Fix

Added \`permissions: contents: read\` to the three \`uses:\` jobs in both \`release-typo3-extension.yml\` and \`republish.yml\`. No runtime behaviour change; they were always implicitly meant to only read.

## Test plan

- [x] \`actionlint\` clean.
- [ ] After merge, re-run v0.8.1 Release in \`netresearch/t3x-nr-passkeys-be\`; orchestrator starts, jobs materialise, end-to-end publish succeeds.