### PR TITLE
fix(release): deduplicate release notes; use composer path for docs URL

### DIFF
--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -117,8 +117,10 @@ jobs:
 
       - name: Generate release notes
         id: notes
-        # Phase 1 keeps the git-log approach used by release.yml. Phase 3 swaps
-        # this for git-cliff + contributor/reporter attribution.
+        # Phase 1: one line per merge commit on main (PR title with #N). Avoids
+        # the duplicate "feature-branch commit + merge commit" noise the naive
+        # `git log` produced. Phase 3 swaps this for git-cliff + contributor
+        # and issue-reporter attribution.
         run: |
           DELIMITER="ghadelim_$(openssl rand -hex 8)"
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
@@ -127,7 +129,15 @@ jobs:
             if [[ -z "$PREVIOUS_TAG" ]]; then
               echo "Initial release"
             else
-              git log --pretty=format:"- %s" "${PREVIOUS_TAG}..HEAD"
+              # --first-parent --merges gives one line per merged PR (the
+              # merge commit's subject carries the PR title and "#N"
+              # reference). Falls back to --no-merges if no merge commits
+              # exist in the range (direct pushes / rebase-merge strategy).
+              LOG=$(git log --first-parent --merges --pretty=format:"- %s" "${PREVIOUS_TAG}..HEAD")
+              if [[ -z "${LOG// }" ]]; then
+                LOG=$(git log --no-merges --pretty=format:"- %s" "${PREVIOUS_TAG}..HEAD")
+              fi
+              echo "$LOG"
               echo ""
             fi
             echo "$DELIMITER"
@@ -300,7 +310,10 @@ jobs:
               echo "- Packagist: skipped"
             fi
             if [[ "$DOCS_RESULT" == "success" ]]; then
-              echo "- Documentation: [docs.typo3.org/p/${VENDOR}/${KEY}/${DOCS_BRANCH}/en-us/](https://docs.typo3.org/p/${VENDOR}/${KEY}/${DOCS_BRANCH}/en-us/) — render verified"
+              # docs.typo3.org path uses the composer package name verbatim
+              # (`{vendor}/{repo-name}` with dashes), NOT the TYPO3 extension
+              # key (which uses underscores).
+              echo "- Documentation: [docs.typo3.org/p/${PACKAGE}/${DOCS_BRANCH}/en-us/](https://docs.typo3.org/p/${PACKAGE}/${DOCS_BRANCH}/en-us/) — render verified"
             elif [[ "$DOCS_RESULT" == "skipped" ]]; then
               echo "- Documentation: skipped"
             fi


### PR DESCRIPTION
Two quality issues observed on v0.8.2 release body, both addressed here.

## Duplicate release notes

Current output:
\`\`\`
- chore: release v0.8.2 (#56)
- chore: release v0.8.2
- fix(docs): replace Documentation/CLAUDE.md symlink with real file (unblocks Intercept render) (#55)
- fix(docs): replace Documentation/CLAUDE.md symlink with file copy
\`\`\`

Each PR appears twice — once as the original feature-branch commit, once as the merge commit on \`main\`. \`git log \${PREV}..HEAD\` walks both parents of the merge.

Fix: \`--first-parent --merges\` — one line per merged PR, using the merge-commit subject (which carries the PR title and \`#N\` reference). Fallback to \`--no-merges\` if the range has no merge commits (rebase-merge-only repos).

Expected next output:
\`\`\`
- chore: release v0.8.2 (#56)
- fix(docs): replace Documentation/CLAUDE.md symlink with real file (unblocks Intercept render) (#55)
\`\`\`

Full narrative (git-cliff + contributor/reporter attribution + Jira links) is still deferred to Phase 3.

## Wrong docs URL in Publication-status block

The evidence block produced:
\`\`\`
docs.typo3.org/p/netresearch/nr_passkeys_be/0.8/en-us/   → 404
\`\`\`

Real URL:
\`\`\`
docs.typo3.org/p/netresearch/nr-passkeys-be/0.8/en-us/   → 200
\`\`\`

docs.typo3.org uses the composer package name (\`vendor/repo-name\` with dashes), not the TYPO3 extension key (with underscores). Use \`package-name\` verbatim.

## Test plan

- [x] \`actionlint\` clean.
- [ ] After merge, any subsequent release gets de-duplicated notes and the correct docs URL in the evidence block.