### PR TITLE
feat(ci): default coverage-tool to xdebug instead of pcov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,16 @@ on:
         type: boolean
         default: false
       coverage-tool:
-        description: Coverage driver (pcov or xdebug)
+        description: >-
+          Coverage driver. "xdebug" (default) delivers branch + path
+          coverage and matches the local `composer ci:test:php:*:coverage`
+          scripts which set XDEBUG_MODE=coverage -- choosing xdebug here
+          eliminates "green locally, red in CI" drift around
+          beStrictAboutCoverageMetadata. "pcov" is line-only but ~3-10x
+          faster; set it explicitly when CI runtime matters more than
+          coverage fidelity.
         type: string
-        default: pcov
+        default: xdebug
 
       # Incompatible dev deps
       remove-dev-deps:

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ jobs:
 | `functional-test-db` | string | `sqlite` | Database: `sqlite`, `mysql`, `mariadb`, `postgres` |
 | `db-image` | string | `mysql:9.6` | Docker image for database service |
 | `upload-coverage` | boolean | `false` | Upload coverage to Codecov |
-| `coverage-tool` | string | `pcov` | Coverage driver: `pcov` or `xdebug` |
+| `coverage-tool` | string | `xdebug` | Coverage driver: `xdebug` (branch + path coverage, matches local `XDEBUG_MODE=coverage`) or `pcov` (line-only, ~3-10× faster) |
 | `remove-dev-deps` | string | `'[]'` | JSON array of dev deps to remove for TYPO3 version compat |
 | `cgl-command` | string | auto-detect | Override CGL command |
 | `phpstan-command` | string | auto-detect | Override PHPStan command |


### PR DESCRIPTION
## Summary

Flip the default \`coverage-tool\` input on the reusable \`ci.yml\` workflow from \`pcov\` to \`xdebug\`. Consumers that prefer pcov-speed can still set it explicitly.

## Why

- **Local/CI parity**: the standard TYPO3 composer scripts (\`ci:test:php:unit:coverage\`, etc.) set \`XDEBUG_MODE=coverage\`. With CI defaulting to pcov, consumers periodically see tests that pass locally and go red in CI for coverage-tool-specific reasons — especially around PHPUnit's \`beStrictAboutCoverageMetadata=\"true\"\`. Observed concretely in [netresearch/t3x-nr-image-optimize#93](https://github.com/netresearch/t3x-nr-image-optimize/pull/93).
- **Richer signal**: xdebug gives branch + path coverage. pcov is line-only. Codecov reports and \`--coverage-html\` become more useful with xdebug data.
- **Cost**: ~2-3 min extra CI runtime across a typical 8-job matrix (measured on t3x-nr-image-optimize). Acceptable trade-off given the consistency gain.

## What changed

- \`.github/workflows/ci.yml\`: \`coverage-tool\` input default \`pcov\` → \`xdebug\`. The description block is expanded to document the tradeoff so future consumers see it on hover in VS Code / \`gh workflow view\`.
- \`README.md\`: table entry updated accordingly.

## Breaking?

Technically a behavior change for consumers that rely on the default. But:
- Opt-out is trivial: one line in \`.github/workflows/ci.yml\` (\`coverage-tool: 'pcov'\`).
- pcov-only code (rare: pcov-specific directives) doesn't exist in normal composer-driven coverage flows.
- CI runtime increase of a few minutes isn't breaking for most TYPO3 extension projects.

Worth calling out in a release note so consumers who deliberately picked pcov know the default changed.

## Test plan

- [ ] Validated on \`netresearch/t3x-nr-image-optimize\`: 30 functional tests × xdebug coverage pass with \`beStrictAboutCoverageMetadata=true\`.
- [ ] No consumer-side changes needed for the main behaviour. One consumer (t3x-nr-image-optimize) explicitly set \`coverage-tool: 'xdebug'\` earlier this week before this default flip — that override becomes redundant after this merges but remains harmless.

## Related

- [netresearch/t3x-nr-image-optimize#93](https://github.com/netresearch/t3x-nr-image-optimize/pull/93) — consumer PR that surfaced this
- [netresearch/t3x-nr-image-optimize#94](https://github.com/netresearch/t3x-nr-image-optimize/pull/94) — TYPO3_12 companion