### PR TITLE
fix(ter): preserve external_manual when manual-url input is empty

### DIFF
--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -23,12 +23,25 @@ on:
         type: number
         default: 30
       update-metadata:
-        description: After publishing, sync the TER listing's manual/issues/repository URLs via `tailor ter:update`. Safe to re-run; TER overwrites with the supplied values.
+        description: >-
+          After publishing, sync the TER listing's composer/issues/repository
+          URLs via `tailor ter:update`. The manual URL is only written
+          when `manual-url` is explicitly set (empty preserves TER's
+          existing value). Safe to re-run; TER overwrites each supplied
+          field.
         required: false
         type: boolean
         default: true
       manual-url:
-        description: Override for the "manual" URL in TER metadata. Defaults to the GitHub repo URL, which is what readers expect from the TER listing's "Manual" link.
+        description: >-
+          URL for TER's "External manual" field. If empty (default), the
+          existing value on TER is preserved -- in particular, TYPO3
+          extensions with composer-docs auto-publish should leave this
+          empty so TER auto-links the "Extension Manual" button to
+          docs.typo3.org/p/<vendor>/<package>/<major>.<minor>/en-us.
+          If set, overwrites TER's field with the supplied URL on every
+          publish (idempotent). Set to a real docs URL only if your
+          extension does NOT auto-publish to docs.typo3.org.
         required: false
         type: string
         default: ''
@@ -312,19 +325,28 @@ jobs:
           fi
 
           REPO_URL="${SERVER_URL}/${REPO}"
-          MANUAL_URL="${MANUAL_INPUT:-$REPO_URL}"
           ISSUES_URL="${ISSUES_INPUT:-${REPO_URL}/issues}"
           REPOSITORY_URL="${REPOSITORY_INPUT:-$REPO_URL}"
 
+          # Build the tailor argv in an array. --manual is appended ONLY
+          # when manual-url is explicitly set -- empty means "preserve
+          # TER's existing value" so composer-docs auto-publish consumers
+          # keep their docs.typo3.org/p/... auto-link intact.
+          TAILOR_ARGS=(
+            "--composer=$COMPOSER_NAME"
+            "--issues=$ISSUES_URL"
+            "--repository=$REPOSITORY_URL"
+          )
+
           echo "Updating TER metadata for $KEY:"
           echo "  composer=$COMPOSER_NAME"
-          echo "  manual=$MANUAL_URL"
+          if [[ -n "$MANUAL_INPUT" ]]; then
+            TAILOR_ARGS+=("--manual=$MANUAL_INPUT")
+            echo "  manual=$MANUAL_INPUT"
+          else
+            echo "  manual=(preserving TER's existing value)"
+          fi
           echo "  issues=$ISSUES_URL"
           echo "  repository=$REPOSITORY_URL"
 
-          php ~/.composer/vendor/bin/tailor ter:update \
-            --composer="$COMPOSER_NAME" \
-            --manual="$MANUAL_URL" \
-            --issues="$ISSUES_URL" \
-            --repository="$REPOSITORY_URL" \
-            "$KEY"
+          php ~/.composer/vendor/bin/tailor ter:update "${TAILOR_ARGS[@]}" "$KEY"

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -38,7 +38,7 @@ on:
           existing value on TER is preserved -- in particular, TYPO3
           extensions with composer-docs auto-publish should leave this
           empty so TER auto-links the "Extension Manual" button to
-          docs.typo3.org/p/<vendor>/<package>/<major>.<minor>/en-us.
+          https://docs.typo3.org/p/<vendor>/<package>/<major>.<minor>/en-us.
           If set, overwrites TER's field with the supplied URL on every
           publish (idempotent). Set to a real docs URL only if your
           extension does NOT auto-publish to docs.typo3.org.

--- a/README.md
+++ b/README.md
@@ -523,6 +523,13 @@ jobs:
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `php-version` | string | `8.4` | PHP version for tailor CLI |
+| `ref` | string | _event ref_ | Git ref (tag or SHA) to check out. Set explicitly when re-triggering from `workflow_dispatch` against a branch. |
+| `verify-timeout-minutes` | number | `10` | Max minutes to wait for TER to serve the published version |
+| `verify-poll-interval-seconds` | number | `30` | Seconds between TER verification polls |
+| `update-metadata` | boolean | `true` | After publish, sync composer/issues/repository URLs via `tailor ter:update`. The manual URL is only written when `manual-url` is non-empty. |
+| `manual-url` | string | `''` | TER's "External manual" field. **Empty preserves TER's existing value** — recommended for extensions that auto-publish to `docs.typo3.org/p/<vendor>/<package>/...` (TER then auto-links the "Extension Manual" button there). Set explicitly only when your extension does NOT auto-publish and you need a custom manual URL. |
+| `issues-url` | string | `''` | TER's "issues" URL. Empty defaults to `${repo}/issues`. |
+| `repository-url` | string | `''` | TER's "repository" URL. Empty defaults to the GitHub repo URL. |
 
 ### Secrets
 
@@ -530,6 +537,14 @@ jobs:
 |--------|----------|-------------|
 | `TYPO3_TER_ACCESS_TOKEN` | Yes | TER API access token |
 | `TYPO3_EXTENSION_KEY` | No | Deprecated: auto-resolved from composer.json |
+
+### Notes on the "External manual" field
+
+TER surfaces a prominent "Extension Manual" button on every listing. If `external_manual` is empty, TER auto-links it to `https://docs.typo3.org/p/<vendor>/<package>/<major>.<minor>/en-us` — the composer-docs auto-publish route. If `external_manual` is set, the button links there instead.
+
+Most TYPO3 extensions that ship a `Documentation/` directory and are listed on Packagist get automatic docs.typo3.org publishing, and the auto-link delivers users to nicely rendered manuals. Writing the GitHub repo URL into `external_manual` would point readers at raw PHP source instead — worse UX, and not what most consumers want.
+
+This workflow defaults to preserving whatever TER currently has for `external_manual` (typically empty for auto-publishing extensions). Only set `manual-url` explicitly if your extension does NOT use docs.typo3.org auto-publish.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ jobs:
 | `verify-timeout-minutes` | number | `10` | Max minutes to wait for TER to serve the published version |
 | `verify-poll-interval-seconds` | number | `30` | Seconds between TER verification polls |
 | `update-metadata` | boolean | `true` | After publish, sync composer/issues/repository URLs via `tailor ter:update`. The manual URL is only written when `manual-url` is non-empty. |
-| `manual-url` | string | `''` | TER's "External manual" field. **Empty preserves TER's existing value** — recommended for extensions that auto-publish to `docs.typo3.org/p/<vendor>/<package>/...` (TER then auto-links the "Extension Manual" button there). Set explicitly only when your extension does NOT auto-publish and you need a custom manual URL. |
+| `manual-url` | string | `''` | TER's "External manual" field. **Empty preserves TER's existing value** — recommended for extensions that auto-publish to `https://docs.typo3.org/p/<vendor>/<package>/...` (TER then auto-links the "Extension Manual" button there). Set explicitly only when your extension does NOT auto-publish and you need a custom manual URL. |
 | `issues-url` | string | `''` | TER's "issues" URL. Empty defaults to `${{ github.server_url }}/${{ github.repository }}/issues`. |
 | `repository-url` | string | `''` | TER's "repository" URL. Empty defaults to `${{ github.server_url }}/${{ github.repository }}`. |
 

--- a/README.md
+++ b/README.md
@@ -528,8 +528,8 @@ jobs:
 | `verify-poll-interval-seconds` | number | `30` | Seconds between TER verification polls |
 | `update-metadata` | boolean | `true` | After publish, sync composer/issues/repository URLs via `tailor ter:update`. The manual URL is only written when `manual-url` is non-empty. |
 | `manual-url` | string | `''` | TER's "External manual" field. **Empty preserves TER's existing value** — recommended for extensions that auto-publish to `docs.typo3.org/p/<vendor>/<package>/...` (TER then auto-links the "Extension Manual" button there). Set explicitly only when your extension does NOT auto-publish and you need a custom manual URL. |
-| `issues-url` | string | `''` | TER's "issues" URL. Empty defaults to `${repo}/issues`. |
-| `repository-url` | string | `''` | TER's "repository" URL. Empty defaults to the GitHub repo URL. |
+| `issues-url` | string | `''` | TER's "issues" URL. Empty defaults to `${{ github.server_url }}/${{ github.repository }}/issues`. |
+| `repository-url` | string | `''` | TER's "repository" URL. Empty defaults to `${{ github.server_url }}/${{ github.repository }}`. |
 
 ### Secrets
 


### PR DESCRIPTION
## Summary

Change the \`publish-to-ter.yml\` reusable workflow so that an **empty** \`manual-url\` input **preserves TER's existing \`external_manual\` value** instead of overwriting it with the GitHub repo URL.

## Why

TER surfaces a prominent "Extension Manual" button on every listing. Its link target depends on the \`external_manual\` field:

- If **empty**: TER auto-links to \`https://docs.typo3.org/p/<vendor>/<package>/<major>.<minor>/en-us\` — the composer-docs auto-publish route. **This is what most TYPO3 extensions want.**
- If **set**: TER uses that URL. Useful for extensions that host docs externally.

The previous behavior fell back an empty \`manual-url\` input to \`https://github.com/<owner>/<repo>\`, overwriting TER's field on every release and pointing users at raw PHP source instead of rendered docs.

### Observed anomaly

On [netresearch/t3x-nr-image-optimize](https://github.com/netresearch/t3x-nr-image-optimize), the workflow has been writing \`external_manual=https://github.com/netresearch/t3x-nr-image-optimize\` on every release — but \`curl https://extensions.typo3.org/api/v1/extension/nr_image_optimize\` consistently shows \`external_manual: \"\"\`. TER appears to silently reject the value server-side. Relying on that rejection is fragile: if TER ever changes behavior, every consumer of this workflow immediately gets a degraded Extension Manual link.

## Behavior change

| | Before | After |
|---|---|---|
| \`manual-url: ''\` (default) | falls back to \`github.com/\${{ github.repository }}\`, overwrites TER | **\`--manual\` not passed to tailor; TER's existing value is preserved** |
| \`manual-url: 'https://...'\` | written to TER verbatim | unchanged — written to TER verbatim |

composer/issues/repository URLs are unchanged (still always synced via tailor).

## Is this breaking?

Technically yes, but in practice rarely:

- Consumers who relied on the default-to-repo-URL fallback can restore prior behavior with one line:
  \`\`\`yaml
  with:
    manual-url: https://github.com/\${{ github.repository }}
  \`\`\`
- Most extensions already have \`external_manual=\"\"\` on TER (never set, or manually cleared, or TER rejected the write — see above).
- Extensions with docs.typo3.org auto-publish **benefit immediately**: the GitHub URL stops getting written, the auto-link stays intact.

Release-note this clearly and cut \`v1.4.0\` (minor bump) to signal the behavioral change.

## Changes

- \`.github/workflows/publish-to-ter.yml\`:
  - Build the tailor argv as an array; append \`--manual=\` only when \`manual-url\` input is non-empty.
  - Inline input description updated with rationale + docs.typo3.org pointer.
  - \`update-metadata\` description clarified to reflect the new conditional.
- \`README.md\`:
  - Inputs table now lists all inputs (previously only \`php-version\`).
  - New "Notes on the External manual field" subsection explaining the docs.typo3.org auto-link and when to override.

## Test plan

- [ ] Next \`netresearch/t3x-nr-image-optimize\` release against \`@main\` (after this merges) should preserve \`external_manual=\"\"\`. Verify via \`curl https://extensions.typo3.org/api/v1/extension/nr_image_optimize | jq '.[0].meta.external_manual'\`.
- [ ] Consumers that explicitly set \`manual-url: https://...\` continue to have that URL written (no change).

## Related

- Consumer discovery: [netresearch/t3x-nr-image-optimize#98](https://github.com/netresearch/t3x-nr-image-optimize/pull/98)