### PR TITLE
fix(phpstan): curate ergebnis rules for TYPO3 compatibility

### DIFF
--- a/config/phpstan/phpstan.neon
+++ b/config/phpstan/phpstan.neon
@@ -2,12 +2,22 @@
 #
 # phpstan/extension-installer (included in this package) auto-registers
 # phpstan-strict-rules, phpstan-deprecation-rules, phpstan-phpunit,
-# phpstan-typo3, and phpat — no manual neon includes needed for those.
+# phpstan-typo3, phpat, and ergebnis/phpstan-rules — no manual neon
+# includes needed for those.
 #
 # IMPORTANT: If your extension previously did NOT use saschaegerer/phpstan-typo3,
 # adding this package will change PHPStan's type inference for TYPO3 APIs
 # (e.g. GeneralUtility::makeInstance() returns proper types instead of mixed).
 # You will need to regenerate your phpstan-baseline.neon after migration.
+#
+# ergebnis/phpstan-rules defaults (allRules: true) enable rules that conflict
+# with standard TYPO3 framework patterns: extending @internal base classes
+# (ActionController, AbstractEntity), named arguments on TYPO3 core APIs,
+# isset(), switch statements, nullable return types, and parameters with null
+# default values. This config disables `allRules` and opts back in to the
+# universally beneficial rules that match TYPO3 coding standards.
+# Override individual `ergebnis.*.enabled` flags in your extension's
+# phpstan.neon to tighten or loosen per-project.
 #
 # Extensions include this file in their own phpstan.neon:
 #
@@ -40,6 +50,27 @@ parameters:
     checkMissingCallableSignature: true
     checkUninitializedProperties: true
     reportUnmatchedIgnoredErrors: true
+
+    # Curated ergebnis/phpstan-rules for TYPO3 compatibility.
+    # Default (allRules: true) breaks every TYPO3 extension by forbidding
+    # extending ActionController / AbstractEntity, named args, isset(),
+    # switch, nullable params, etc. We opt-in only to rules that align
+    # with TYPO3 coding standards.
+    ergebnis:
+        allRules: false
+        # Style / safety rules that align with TYPO3 coding standards:
+        declareStrictTypes:
+            enabled: true
+        noCompact:
+            enabled: true
+        noErrorSuppression:
+            enabled: true
+        noEval:
+            enabled: true
+        noReturnByReference:
+            enabled: true
+        testCaseWithSuffix:
+            enabled: true
 
     excludePaths:
         - %currentWorkingDirectory%/.Build/*


### PR DESCRIPTION
## Problem

v1.3.0 (released 2026-04-24 12:19 UTC) re-added `ergebnis/phpstan-rules` as a direct dependency — the package had been dropped in v1.2.0. Since `ergebnis/phpstan-rules` auto-registers via `phpstan/extension-installer` and defaults to `ergebnis.allRules: true`, every consumer extension's PHPStan matrix turned red within minutes.

## Evidence

- [nr-llm CI on main](https://github.com/netresearch/t3x-nr-llm/actions/runs/24889021144) — green until PR #147 (12:09 UTC, composer resolved to `v1.2.0`), red from PR #148 onward (12:16 UTC, composer resolved to `v1.3.0`). 1000+ PHPStan errors.
- Representative errors:
  - `Class "…\Controller\Backend\ConfigurationController" is not allowed to extend "TYPO3\CMS\Extbase\Mvc\Controller\ActionController"` (`ergebnis.final`)
  - `Class "…\Domain\Model\LlmConfiguration" is not allowed to extend "TYPO3\CMS\Extbase\DomainObject\AbstractEntity"` (`ergebnis.final`)
  - `Method TYPO3\CMS\Backend\Template\Components\DocHeaderComponent::setShortcutContext() is invoked with named argument for parameter $displayName` (`ergebnis.noNamedArgument`)
  - `Language construct isset() should not be used` (`ergebnis.noIsset`)

These are all standard TYPO3 patterns — you cannot write a TYPO3 extension without extending `ActionController`, extending `AbstractEntity`, or using `isset`.

## Fix

Set `ergebnis.allRules: false` and opt in to the six rules that clearly align with TYPO3 coding standards:

| Rule | Rationale |
|------|-----------|
| `declareStrictTypes` | TYPO3 coding standards require `declare(strict_types=1);` |
| `noCompact` | Obscure construct, readable alternatives exist |
| `noErrorSuppression` | `@`-suppression hides bugs; use proper error handlers |
| `noEval` | Security-critical |
| `noReturnByReference` | Obscure and error-prone |
| `testCaseWithSuffix` | Enforces `*Test.php` naming convention |

Disabled (incompatible with TYPO3 framework requirements):

- `final`, `noExtends` — extensions MUST extend `ActionController` / `AbstractEntity` / `AbstractController`
- `noNamedArgument` — TYPO3 v12+ core APIs (`DocHeaderComponent::setShortcutContext`, `ModuleTemplate`, etc.) are designed for named-argument call sites
- `noIsset`, `noSwitch` — fundamental PHP constructs
- `noNullableReturnTypeDeclaration`, `noParameterWithNullableTypeDeclaration` — TYPO3 core APIs use these extensively
- `noParameterWithNullDefaultValue`, `noConstructorParameterWithDefaultValue` — common TYPO3 pattern
- `noParameterPassedByReference`, `noAssignByReference` — needed for `sort()`, `usort()`, etc.
- `noParameterWithContainerTypeDeclaration` — needed for DI compiler passes
- `privateInFinalClass` — TYPO3 extensions cannot make classes `final` (see above)
- `noPhpstanIgnore` — baselines are a valid migration tool
- `finalInAbstractClass`, `invokeParentHookMethod` — too opinionated for library code

Consumer extensions can override any `ergebnis.*.enabled` flag in their own `phpstan.neon` to tighten or loosen per-project.

## Verification

Applied to `netresearch/t3x-nr-llm` locally:

- Before: 1000+ PHPStan errors (truncated at limit)
- After: 6 errors, all legitimate `@`-suppression usages in `file_get_contents` / `file_put_contents` / `unlink` — project-specific cleanup, not framework-level

## Release plan

This is an urgent fix — main branches of multiple TYPO3 extensions are red. Recommend cutting `v1.3.1` immediately after merge.

## Signed-off-by

Sebastian Mendel <sebastian.mendel@netresearch.de>