### PR TITLE
chore: address Copilot review backlog from PRs #66, #68, #69, #70, #71

### DIFF
--- a/.github/workflows/publish-to-docs.yml
+++ b/.github/workflows/publish-to-docs.yml
@@ -82,6 +82,11 @@ jobs:
           DEADLINE=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
           GRACE_DEADLINE=$(( $(date +%s) + GRACE_SECONDS ))
           RUN_ID=""
+          # Track whether any jobs query has succeeded so far. If the
+          # grace window expires with zero successful jobs queries, the
+          # problem is the API (rate limit / auth), not Intercept —
+          # report accordingly instead of misleading on the webhook.
+          JOBS_QUERY_OK=false
           echo "Looking for render job named: $JOB_NAME"
           echo "Only considering runs created on or after: $SINCE"
 
@@ -120,6 +125,7 @@ jobs:
                 echo "::warning::Failed to list jobs for run ${ID}: ${JOBS_JSON}"
                 continue
               fi
+              JOBS_QUERY_OK=true
               MATCH=$(echo "$JOBS_JSON" \
                 | jq -r --arg job_name "$JOB_NAME" '.jobs[] | select(.name == $job_name) | .id' \
                 | head -n 1 || true)
@@ -137,7 +143,11 @@ jobs:
             fi
 
             if [[ $(date +%s) -ge $GRACE_DEADLINE ]]; then
-              echo "::error::No render run for '${JOB_NAME}' appeared within ${GRACE_SECONDS}s — Intercept webhook may not have fired."
+              if [[ "$JOBS_QUERY_OK" != "true" ]]; then
+                echo "::error::Could not inspect any candidate run's jobs within ${GRACE_SECONDS}s — every jobs API query failed (likely auth or secondary rate limiting). This is NOT an Intercept-webhook problem; check the warnings above."
+              else
+                echo "::error::No render run for '${JOB_NAME}' appeared within ${GRACE_SECONDS}s — Intercept webhook may not have fired."
+              fi
               exit 1
             fi
             echo "No matching render run yet. Retrying in ${POLL_INTERVAL}s."

--- a/.github/workflows/publish-to-docs.yml
+++ b/.github/workflows/publish-to-docs.yml
@@ -90,9 +90,16 @@ jobs:
             # Fetch the most recent render-workflow runs (default page is 30);
             # that window is large enough to contain our run across all
             # typical Intercept dispatch delays without paginating.
-            RUNS_JSON=$(gh api \
+            # Surface gh api errors instead of swallowing them — a transient
+            # auth/rate-limit failure shouldn't be misreported as
+            # "Intercept didn't fire". Capture stderr so the error message
+            # lands in the workflow log.
+            if ! RUNS_JSON=$(gh api \
               "repos/TYPO3-Documentation/t3docs-ci-deploy/actions/workflows/main-rendering.yml/runs?per_page=30" \
-              --jq '.workflow_runs' 2>/dev/null || echo '[]')
+              --jq '.workflow_runs' 2>&1); then
+              echo "::error::Failed to list render workflow runs: ${RUNS_JSON}"
+              exit 1
+            fi
 
             # For each run, ask the jobs endpoint whether our render job is
             # present. We cannot filter runs by inner-job-name server-side;
@@ -104,10 +111,18 @@ jobs:
               if [[ "$CREATED" < "$SINCE" ]]; then
                 continue
               fi
-              MATCH=$(gh api \
-                "repos/TYPO3-Documentation/t3docs-ci-deploy/actions/runs/${ID}/jobs" \
-                --jq ".jobs[] | select(.name == \"${JOB_NAME}\") | .id" \
-                2>/dev/null | head -n 1 || true)
+              # Fetch jobs JSON, then run jq with --arg so JOB_NAME is safely
+              # quoted (a `"` or other special character in package-name
+              # would otherwise break the jq filter and silently miss the
+              # match). Surface API errors instead of swallowing them.
+              if ! JOBS_JSON=$(gh api \
+                "repos/TYPO3-Documentation/t3docs-ci-deploy/actions/runs/${ID}/jobs" 2>&1); then
+                echo "::warning::Failed to list jobs for run ${ID}: ${JOBS_JSON}"
+                continue
+              fi
+              MATCH=$(echo "$JOBS_JSON" \
+                | jq -r --arg job_name "$JOB_NAME" '.jobs[] | select(.name == $job_name) | .id' \
+                | head -n 1 || true)
               if [[ -n "$MATCH" ]]; then
                 RUN_ID="$ID"
                 JOB_ID="$MATCH"
@@ -129,11 +144,17 @@ jobs:
             sleep "$POLL_INTERVAL"
           done
 
-          # Phase 2: wait for the matched job to finish.
+          # Phase 2: wait for the matched job to finish. Surface API errors
+          # so a transient auth/rate-limit failure isn't retried silently
+          # until the job timeout fires.
           while true; do
-            JOB_STATE=$(gh api \
+            if ! JOB_STATE=$(gh api \
               "repos/TYPO3-Documentation/t3docs-ci-deploy/actions/jobs/${JOB_ID}" \
-              --jq '"\(.status):\(.conclusion // "-")"' 2>/dev/null || echo "error:-")
+              --jq '"\(.status):\(.conclusion // "-")"' 2>&1); then
+              echo "::error::Failed to query docs render job state: ${JOB_STATE}"
+              echo "::error::See https://github.com/TYPO3-Documentation/t3docs-ci-deploy/actions/runs/${RUN_ID}"
+              exit 1
+            fi
             case "$JOB_STATE" in
               completed:success)
                 echo "docs render succeeded — https://github.com/TYPO3-Documentation/t3docs-ci-deploy/actions/runs/${RUN_ID}"

--- a/.github/workflows/publish-to-docs.yml
+++ b/.github/workflows/publish-to-docs.yml
@@ -28,8 +28,10 @@ on:
       since:
         description: |
           ISO-8601 timestamp; only render runs created on or after this moment
-          are considered. Defaults to this workflow's own start-time, which
-          works when the orchestrator calls us right after the tag push.
+          are considered. If omitted, the workflow falls back to a timestamp
+          approximately 5 minutes in the past to locate the matching render
+          run (covers the typical Intercept dispatch delay when the
+          orchestrator calls us right after the tag push).
         required: false
         type: string
         default: ''

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -24,11 +24,13 @@ on:
         default: 30
       update-metadata:
         description: >-
-          After publishing, sync the TER listing's composer/issues/repository
-          URLs via `tailor ter:update`. The manual URL is only written
-          when `manual-url` is explicitly set (empty preserves TER's
-          existing value). Safe to re-run; TER overwrites each supplied
-          field.
+          Sync the TER listing's composer/issues/repository URLs via
+          `tailor ter:update`. Runs after publishing, and also on a
+          no-op republish when the version is already on TER (so a
+          repo rename or URL change reconciles without a new release).
+          The manual URL is only written when `manual-url` is
+          explicitly set (empty preserves TER's existing value).
+          Safe to re-run; TER overwrites each supplied field.
         required: false
         type: boolean
         default: true

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -307,8 +307,6 @@ jobs:
         if: inputs.update-metadata
         env:
           KEY: ${{ steps.extkey.outputs.key }}
-          PACKAGE: ${{ github.repository }}
-          COMPOSER_NAME: ''
           TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
           SERVER_URL: ${{ github.server_url }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -22,6 +22,16 @@ on:
         required: false
         type: number
         default: 30
+      job-timeout-minutes:
+        description: |
+          Hard upper bound on the publish job. Must cover
+          `verify-timeout-minutes` plus a buffer (~10 min) for setup,
+          install, publish, and metadata-sync. Bump this whenever you
+          raise `verify-timeout-minutes` so the verify loop isn't cut
+          short by the job budget.
+        required: false
+        type: number
+        default: 25
       update-metadata:
         description: >-
           Sync the TER listing's composer/issues/repository URLs via
@@ -70,7 +80,12 @@ jobs:
   publish:
     name: Publish to TER
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # GitHub Actions expressions don't support arithmetic, so we can't
+    # auto-derive `verify-timeout-minutes + buffer` here. Callers that
+    # raise `verify-timeout-minutes` above the default must also raise
+    # `job-timeout-minutes` to keep the verify loop from being cut
+    # short by the job budget.
+    timeout-minutes: ${{ inputs.job-timeout-minutes }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -40,10 +40,12 @@ on:
         required: true
         type: string
       vendor:
-        description: 'docs.typo3.org vendor segment (owner of the docs URL)'
+        description: |
+          Deprecated, no longer consumed. The docs.typo3.org URL is derived
+          from package-name now. Safe to omit.
         required: false
         type: string
-        default: netresearch
+        default: ''
       include-sbom:
         description: Include SPDX and CycloneDX SBOMs as release assets
         required: false
@@ -286,7 +288,6 @@ jobs:
         env:
           PACKAGE: ${{ inputs.package-name }}
           KEY: ${{ inputs.extension-key }}
-          VENDOR: ${{ inputs.vendor }}
           VERSION: ${{ needs.build-and-sign.outputs.version }}
           TER_RESULT: ${{ needs.publish-to-ter.result }}
           PKGST_RESULT: ${{ needs.verify-packagist.result }}

--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -95,6 +95,23 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Preflight TER token
+        # When `secrets:` is mapped explicitly on a `uses:` job, GitHub
+        # Actions treats the entry as "present" regardless of whether the
+        # value resolved to a real string or an empty one — so the
+        # called workflow's `required: true` declaration is satisfied
+        # even if the consumer never set the secret. Fail here with a
+        # clear message instead of letting `tailor ter:publish` fail
+        # later with a less direct API auth error.
+        if: ${{ !inputs.skip-ter }}
+        env:
+          TER_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
+        run: |
+          if [[ -z "$TER_TOKEN" ]]; then
+            echo "::error::TYPO3_TER_ACCESS_TOKEN secret is required when skip-ter=false"
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -7,21 +7,21 @@ name: Release (TYPO3 extension)
 #   1. build-and-sign — create archives, SBOMs, checksums, Cosign signatures,
 #      build-provenance attestations. Uploads everything as the `dist` run
 #      artifact. No external publishing yet.
-#   2. publish-to-ter, publish-to-packagist — run in parallel after the build
-#      succeeds. Each sub-workflow is idempotent and polls its respective
-#      service until the new version is visible.
-#   3. publish-to-docs — polls docs.typo3.org AFTER TER confirms, because the
-#      TER → Intercept webhook is what triggers the docs render.
-#   4. create-release — the GitHub release is created LAST, in a single
+#   2. publish-to-ter, verify-packagist, verify-docs — all run in parallel
+#      after the build succeeds. docs.typo3.org renders via Intercept's
+#      GitHub-push webhook (independent of TER), so the docs verifier is not
+#      coupled to the TER publish. Each sub-workflow is idempotent and polls
+#      its respective service until the new version is visible.
+#   3. create-release — the GitHub release is created LAST, in a single
 #      atomic `softprops/action-gh-release` call, with every artifact and the
 #      verification-evidence block already determined. Compatible with GitHub
 #      "Immutable Releases": nothing is added, removed, or edited after
 #      publication.
 #
-# If any of steps 2–3 fail, step 4 is skipped: no release is created, the
-# tag exists without a GitHub release, and the maintainer re-runs the whole
-# orchestrator (which is idempotent on every publish step) to finish. The
-# `republish.yml` dispatcher is for recovering a completed release whose
+# If any of step 2's sub-jobs fail, step 3 is skipped: no release is created,
+# the tag exists without a GitHub release, and the maintainer re-runs the
+# whole orchestrator (which is idempotent on every publish step) to finish.
+# The `republish.yml` dispatcher is for recovering a completed release whose
 # publishes later regressed — not for mid-release crashes.
 
 on:
@@ -211,10 +211,11 @@ jobs:
     if: ${{ !inputs.skip-ter }}
     # Declare permissions at the calling-job level so GitHub's startup-time
     # validator sees that we can cover publish-to-ter.yml's inner
-    # `contents: read`. Without this the workflow fails with `startup_failure`
-    # and zero materialised jobs — the inner reusable's permissions cannot
-    # exceed what the caller job grants, and the workflow-level
-    # `permissions: {}` (no default) does not propagate to `uses:` jobs.
+    # `contents: read`. The workflow-level `permissions: {}` is empty and
+    # is inherited by `uses:` jobs just like by regular jobs — but an
+    # inherited empty set cannot satisfy the called workflow's required
+    # `contents: read`, so without this per-job grant the workflow fails
+    # with `startup_failure` and zero materialised jobs.
     permissions:
       contents: read
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main

--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -223,7 +223,11 @@ jobs:
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
     with:
       ref: ${{ github.ref }}
-    secrets: inherit
+    # Explicit secret pass-through (NOT `secrets: inherit`) so a
+    # compromised action in the called workflow can't reach unrelated
+    # org secrets. Forwards only the TER token actually needed.
+    secrets:
+      TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
 
   verify-packagist:
     name: Verify Packagist

--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -131,11 +131,17 @@ jobs:
             if [[ -z "$PREVIOUS_TAG" ]]; then
               echo "Initial release"
             else
-              # --first-parent --merges gives one line per merged PR (the
-              # merge commit's subject carries the PR title and "#N"
-              # reference). Falls back to --no-merges if no merge commits
-              # exist in the range (direct pushes / rebase-merge strategy).
-              LOG=$(git log --first-parent --merges --pretty=format:"- %s" "${PREVIOUS_TAG}..HEAD")
+              # --first-parent gives one line per commit on the trunk's
+              # first-parent line: merge commits (PR title with "#N")
+              # *and* any direct hotfix commits that landed straight on
+              # main without a PR. The earlier `--first-parent --merges`
+              # variant dropped direct commits whenever the range
+              # contained at least one merge — a release that mixed both
+              # would silently lose the direct ones.
+              # Falls back to --no-merges if --first-parent returns
+              # empty (rebase-merge strategy with squash + linear history
+              # rooted on a non-trunk branch — uncommon, but harmless).
+              LOG=$(git log --first-parent --pretty=format:"- %s" "${PREVIOUS_TAG}..HEAD")
               if [[ -z "${LOG// }" ]]; then
                 LOG=$(git log --no-merges --pretty=format:"- %s" "${PREVIOUS_TAG}..HEAD")
               fi

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -31,9 +31,14 @@ on:
         type: string
         default: ''
       package-name:
-        description: Composer package name
-        required: true
+        description: |
+          Composer package name. Required when target is `packagist`,
+          `docs`, or `all`. Optional (and ignored) when target is `ter`,
+          since publish-to-ter.yml resolves the package from
+          composer.json on the checked-out ref.
+        required: false
         type: string
+        default: ''
       vendor:
         description: |
           Deprecated, no longer consumed. The docs.typo3.org URL is derived
@@ -49,7 +54,7 @@ permissions: {}
 
 jobs:
   resolve-version:
-    name: Resolve version from tag
+    name: Validate inputs and resolve version
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
@@ -61,6 +66,50 @@ jobs:
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
+
+      - name: Validate target
+        env:
+          TARGET: ${{ inputs.target }}
+        run: |
+          # Reject unknown target values explicitly; otherwise every
+          # republish-* job's `if:` evaluates false and the workflow
+          # silently succeeds with no work done — a typo would look
+          # indistinguishable from a real republish.
+          case "$TARGET" in
+            ter|docs|packagist|all) ;;
+            *)
+              echo "::error::Invalid target: '$TARGET' (expected one of: ter, docs, packagist, all)"
+              exit 1
+              ;;
+          esac
+
+      - name: Validate per-target inputs
+        env:
+          TARGET: ${{ inputs.target }}
+          PACKAGE_NAME: ${{ inputs.package-name }}
+          TER_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
+        run: |
+          # package-name is needed by Packagist and docs verification;
+          # TER resolves the package from composer.json instead.
+          case "$TARGET" in
+            packagist|docs|all)
+              if [[ -z "$PACKAGE_NAME" ]]; then
+                echo "::error::package-name is required when target is '$TARGET'"
+                exit 1
+              fi
+              ;;
+          esac
+
+          # Preflight the TER token so the failure surfaces here with a
+          # clear message, not deep inside publish-to-ter.yml.
+          case "$TARGET" in
+            ter|all)
+              if [[ -z "$TER_TOKEN" ]]; then
+                echo "::error::TYPO3_TER_ACCESS_TOKEN secret is required when target is '$TARGET'"
+                exit 1
+              fi
+              ;;
+          esac
 
       - name: Strip v-prefix
         id: v
@@ -83,7 +132,11 @@ jobs:
     uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
     with:
       ref: ${{ inputs.tag }}
-    secrets: inherit
+    # Explicit secret pass-through (NOT `secrets: inherit`) so a
+    # compromised action in the called workflow can't reach unrelated
+    # org secrets. Forwards only the TER token actually needed.
+    secrets:
+      TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
 
   republish-packagist:
     name: Packagist

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -23,18 +23,24 @@ on:
         required: true
         type: string   # 'ter' | 'docs' | 'packagist' | 'all'
       extension-key:
-        description: Extension key as registered on TER/docs.typo3.org
-        required: true
+        description: |
+          Deprecated, no longer consumed. publish-to-ter.yml now resolves the
+          extension key from composer.json. Kept as an optional input so
+          existing callers don't break — safe to omit.
+        required: false
         type: string
+        default: ''
       package-name:
         description: Composer package name
         required: true
         type: string
       vendor:
-        description: docs.typo3.org vendor segment
+        description: |
+          Deprecated, no longer consumed. The docs.typo3.org URL is derived
+          from package-name now. Safe to omit.
         required: false
         type: string
-        default: netresearch
+        default: ''
     secrets:
       TYPO3_TER_ACCESS_TOKEN:
         required: false


### PR DESCRIPTION
## Summary

Closes the 17 unresolved Copilot review threads accumulated across PRs
[#66](https://github.com/netresearch/typo3-ci-workflows/pull/66),
[#68](https://github.com/netresearch/typo3-ci-workflows/pull/68),
[#69](https://github.com/netresearch/typo3-ci-workflows/pull/69),
[#70](https://github.com/netresearch/typo3-ci-workflows/pull/70), and
[#71](https://github.com/netresearch/typo3-ci-workflows/pull/71).

Threads were merged before being addressed; this PR is the cleanup.

Six commits, grouped by concern (each commit references the specific
thread IDs it closes):

1. `e84698e` docs(ci): fix workflow docblock and input descriptions — #66.4, #68, #69.1, #71.1
2. `6ba8c9d` chore(ci): drop unused inputs and env vars — #69.5, #70.2, #71.3
3. `c524f84` feat(ci): add `job-timeout-minutes` input to publish-to-ter — #66.5, #71.2
4. `a2c6b59` fix(ci): surface `gh api` failures and quote-safe jq filter — #69.2, #69.3, #69.4
5. `7013f50` feat(ci): validate republish inputs and forward secrets explicitly — #66.1, #66.2, #66.3 (plus a CLAUDE.md/security fix that replaces `secrets: inherit` with explicit pass-through, per the trivy-action supply-chain incident)
6. `3793cb0` fix(ci): include direct commits in release-notes generation — #70.1

#66.6 (`docs-url` unused output in publish-to-docs) was already fixed by
PR #69's docs-verification refactor — only the thread itself needs
resolving.

## Behavior changes worth flagging

- **`republish.yml` validation now fails fast** on unknown `target`
  values, on missing `package-name` for non-TER targets, and on a
  missing `TYPO3_TER_ACCESS_TOKEN` for TER targets. This is a
  strict tightening — callers that were relying on the silent no-op
  for typos will now see an error.
- **`publish-to-ter.yml` adds `job-timeout-minutes` (default 25)** so
  the verify loop and the metadata-sync step can both fit within the
  job budget when callers raise `verify-timeout-minutes`. New
  optional input; existing callers unaffected.
- **`secrets: inherit` replaced by explicit pass-through** on both
  `republish.yml` and `release-typo3-extension.yml`. Callers don't
  see any change — the same `TYPO3_TER_ACCESS_TOKEN` secret still
  flows through.
- **`extension-key`, `vendor`, and `package-name` (in `republish.yml`
  for TER-only)** are now optional/deprecated. Existing callers
  passing them continue to work; future callers can omit them.

Each behavior change exercises a real release flow that this PR
itself can't trigger — they will only be validated end-to-end on the
next consumer release. Listed here so reviewers know what to watch
for.

## Test plan

- [x] actionlint passes locally on all four touched workflows
- [ ] CI (yamllint, actionlint via reviewdog, dependency-review,
      ossf-scorecard) is green
- [ ] Copilot review on this PR has no new findings
- [ ] All 17 original threads on PRs #66/#68/#69/#70/#71 marked
      resolved with a pointer to the commit that addresses them