### PR TITLE
feat(e2e): support setup-variants matrix and custom setup-script

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,6 +158,15 @@ jobs:
       # owns the full lifecycle (install deps, setup DB, start servers,
       # run tests). The workflow just hands it the matrix env vars and
       # runs it.
+      #
+      # Runtime tooling in scripted mode: the workflow only guarantees
+      # the runner-installed `php-version` (via setup-php above). It
+      # does NOT install Node.js, Playwright browsers, Docker tooling,
+      # or anything else — scripted-mode consumers typically run their
+      # full stack inside containers (Apache+PHP-FPM, MariaDB, Playwright)
+      # using the Docker daemon preinstalled on `ubuntu-latest`. If your
+      # script needs Node/npm on the host, install them inside the
+      # script itself so the dependency is explicit.
       - name: Run custom setup script
         if: inputs.setup-script != ''
         env:
@@ -194,17 +203,39 @@ jobs:
           # If a TYPO3 version constraint is specified for this matrix
           # entry, override the consumer's composer.json constraints
           # for the listed packages before installing.
+          #
+          # Two paths depending on whether composer.lock is committed:
+          # - Lock present (typical for application/distribution repos):
+          #   `composer require --no-update` would leave composer.lock
+          #   out of sync, and the subsequent `composer install` would
+          #   fail with "lock file out of sync". Use a single
+          #   `composer require --with-all-dependencies` call instead,
+          #   which atomically updates composer.json + composer.lock and
+          #   resolves transitive constraints.
+          # - Lock absent (typical for TYPO3 extension/library repos —
+          #   composer.lock is usually gitignored): split require/install
+          #   for clarity; `composer install` then resolves fresh.
           if [[ -n "$TYPO3_VERSION" ]]; then
             PACKAGES=$(echo "$TYPO3_PACKAGES" | jq -r '.[]') || {
               echo "::error::Failed to parse typo3-packages input: $TYPO3_PACKAGES"
               exit 1
             }
+            REQUIRE_ARGS=()
             for pkg in $PACKAGES; do
-              echo "Bumping ${pkg} to ${TYPO3_VERSION} for this matrix entry"
-              composer require --no-update --no-interaction "${pkg}:${TYPO3_VERSION}"
+              REQUIRE_ARGS+=("${pkg}:${TYPO3_VERSION}")
             done
+            echo "Bumping packages to ${TYPO3_VERSION}: ${REQUIRE_ARGS[*]}"
+            if [[ -f composer.lock ]]; then
+              composer require --with-all-dependencies --no-interaction --no-progress "${REQUIRE_ARGS[@]}"
+            else
+              for arg in "${REQUIRE_ARGS[@]}"; do
+                composer require --no-update --no-interaction "$arg"
+              done
+              composer install --prefer-dist --no-progress
+            fi
+          else
+            composer install --prefer-dist --no-progress
           fi
-          composer install --prefer-dist --no-progress
 
       - name: Ensure typo3/cms-install is available
         if: inputs.setup-script == ''
@@ -395,6 +426,28 @@ jobs:
           TEST_COMMAND: ${{ inputs.test-command }}
         run: bash -c "$TEST_COMMAND"
 
+      # ─── Common: compute artifact name suffix ──────────────────────
+      # Sanitize matrix values for safe artifact names. GitHub allows
+      # most chars but disallows / \ : < > | * ? \r \n; matrix values
+      # like "^14.3" contain `^` which is technically allowed but
+      # awkward. We strip everything outside [A-Za-z0-9._-] to keep
+      # artifact names predictable and grep-friendly.
+      - name: Compute artifact suffix
+        id: artifact-suffix
+        env:
+          MATRIX_TYPO3: ${{ matrix.typo3 }}
+          MATRIX_VARIANT: ${{ matrix.variant }}
+        run: |
+          sanitize() { echo "$1" | sed 's/[^A-Za-z0-9._-]/_/g; s/__*/_/g; s/^_//; s/_$//'; }
+          SUFFIX=""
+          if [[ -n "$MATRIX_TYPO3" ]]; then
+            SUFFIX="${SUFFIX}-$(sanitize "$MATRIX_TYPO3")"
+          fi
+          if [[ -n "$MATRIX_VARIANT" ]]; then
+            SUFFIX="${SUFFIX}-$(sanitize "$MATRIX_VARIANT")"
+          fi
+          echo "value=${SUFFIX}" >> "$GITHUB_OUTPUT"
+
       # ─── Common: artifact upload (both modes) ──────────────────────
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -402,15 +455,7 @@ jobs:
         with:
           # Disambiguate artifact name across matrix entries to avoid
           # GitHub's "artifact already exists" error for multi-variant runs.
-          name: >-
-            playwright-report${{
-              (matrix.typo3 != '' || matrix.variant != '')
-                && format('-{0}{1}{2}',
-                          matrix.typo3,
-                          (matrix.typo3 != '' && matrix.variant != '') && '-' || '',
-                          matrix.variant)
-              || ''
-            }}
+          name: playwright-report${{ steps.artifact-suffix.outputs.value }}
           path: ${{ inputs.artifact-path }}
           retention-days: 7
 
@@ -418,15 +463,7 @@ jobs:
         if: inputs.setup-script == '' && failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: >-
-            php-server-logs${{
-              (matrix.typo3 != '' || matrix.variant != '')
-                && format('-{0}{1}{2}',
-                          matrix.typo3,
-                          (matrix.typo3 != '' && matrix.variant != '') && '-' || '',
-                          matrix.variant)
-              || ''
-            }}
+          name: php-server-logs${{ steps.artifact-suffix.outputs.value }}
           path: /tmp/php-server.log
           retention-days: 3
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       php-version:
-        description: PHP version
+        description: PHP version (used in default mode; setup-script may override)
         type: string
         default: '8.4'
       node-version:
@@ -12,7 +12,7 @@ on:
         type: string
         default: '24'
       typo3-setup-extensions:
-        description: Run extension:setup after TYPO3 setup
+        description: Run extension:setup after TYPO3 setup (default mode only)
         type: boolean
         default: true
       playwright-browser:
@@ -20,11 +20,11 @@ on:
         type: string
         default: 'chromium'
       test-command:
-        description: E2E test command
+        description: E2E test command (default mode only — setup-script owns its test invocation)
         type: string
         default: 'npm run test:e2e'
       db-image:
-        description: Database Docker image
+        description: Database Docker image (default mode only)
         type: string
         default: 'mariadb:11.4'
       php-extensions:
@@ -40,22 +40,88 @@ on:
         type: string
         default: 'Tests/E2E/Playwright/reports/'
       web-dir:
-        description: TYPO3 web directory (document root for PHP server)
+        description: TYPO3 web directory (document root for PHP server, default mode only)
         type: string
         default: '.Build/Web'
+
+      # Matrix dimensions — both default to a single empty entry, preserving
+      # the original single-job behavior for existing consumers. Pass a
+      # multi-entry JSON array to expand the matrix.
+      typo3-versions:
+        description: >-
+          JSON array of TYPO3 core version constraints to test against
+          (e.g. '["^13.4.21","^14.3"]'). Each entry runs as a separate
+          matrix job, with the constraint applied to packages listed in
+          `typo3-packages` via `composer require --no-update`. The empty
+          string ("") means "use composer.json as-is, no override". Default
+          '[""]' = single job using existing composer.json.
+        type: string
+        default: '[""]'
+      typo3-packages:
+        description: >-
+          JSON array of TYPO3 packages whose constraints get bumped per
+          matrix entry. Only used when `typo3-versions` contains
+          non-empty entries.
+        type: string
+        default: '["typo3/cms-core"]'
+      setup-variants:
+        description: >-
+          JSON array of setup variant names. Each variant runs as a
+          separate matrix job. Variant name is passed to `setup-script`
+          as $E2E_VARIANT and (in default mode) to `test-command` env.
+          Use this to test the extension under different sitepackage /
+          fluid-styled-content / Bootstrap-Package combinations.
+          Default '[""]' = single job, no variant axis.
+        type: string
+        default: '[""]'
+
+      # Custom setup hook for extensions whose E2E setup doesn't fit the
+      # default workflow shape (e.g. containerized Apache+PHP-FPM,
+      # custom DB seeding, Content Blocks fixture installation, etc.)
+      setup-script:
+        description: >-
+          Path to a custom setup script (relative to repo root). When
+          provided, the script REPLACES the entire default pipeline —
+          it is responsible for installing dependencies, setting up
+          TYPO3, starting any servers, AND running the tests. The
+          workflow only handles checkout, env setup, and artifact
+          upload around it. Env vars passed in: E2E_VARIANT,
+          E2E_TYPO3_VERSION, E2E_TYPO3_PACKAGES (JSON array). Empty
+          string (default) = use built-in default pipeline.
+        type: string
+        default: ''
 
 permissions: {}
 
 jobs:
   e2e:
-    name: Playwright E2E Tests
+    # Surface the matrix entry in the job name so multi-variant runs are
+    # distinguishable in CI logs. Falls back to a plain "E2E" label when
+    # neither matrix axis is in use.
+    name: >-
+      ${{ matrix.typo3 != '' && matrix.variant != ''
+            && format('E2E (TYPO3 {0}, {1})', matrix.typo3, matrix.variant)
+          || matrix.typo3 != ''
+            && format('E2E (TYPO3 {0})', matrix.typo3)
+          || matrix.variant != ''
+            && format('E2E ({0})', matrix.variant)
+          || 'E2E' }}
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        typo3: ${{ fromJSON(inputs.typo3-versions) }}
+        variant: ${{ fromJSON(inputs.setup-variants) }}
 
     services:
       db:
+        # The MariaDB service is always started (GitHub Actions doesn't
+        # support conditional services). In scripted mode, custom setup
+        # scripts that bring their own DB simply ignore this service —
+        # it adds ~5s to job startup but no other cost.
         image: ${{ inputs.db-image }}
         env:
           MYSQL_ROOT_PASSWORD: root
@@ -87,21 +153,61 @@ jobs:
           extensions: ${{ inputs.php-extensions }}
           coverage: none
 
+      # ─── Scripted mode ─────────────────────────────────────────────
+      # When `setup-script` is provided, the consumer-supplied script
+      # owns the full lifecycle (install deps, setup DB, start servers,
+      # run tests). The workflow just hands it the matrix env vars and
+      # runs it.
+      - name: Run custom setup script
+        if: inputs.setup-script != ''
+        env:
+          E2E_VARIANT: ${{ matrix.variant }}
+          E2E_TYPO3_VERSION: ${{ matrix.typo3 }}
+          E2E_TYPO3_PACKAGES: ${{ inputs.typo3-packages }}
+          SETUP_SCRIPT: ${{ inputs.setup-script }}
+        run: bash "$SETUP_SCRIPT"
+
+      # ─── Default mode ──────────────────────────────────────────────
+      # Original built-in pipeline, gated on `setup-script` being empty.
+      # Each step below is a no-op in scripted mode.
       - name: Get Composer cache directory
+        if: inputs.setup-script == ''
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer dependencies
+        if: inputs.setup-script == ''
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-e2e-${{ inputs.php-version }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-e2e-${{ inputs.php-version }}-
+          key: ${{ runner.os }}-composer-e2e-${{ inputs.php-version }}-${{ matrix.typo3 }}-${{ matrix.variant }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-e2e-${{ inputs.php-version }}-${{ matrix.typo3 }}-${{ matrix.variant }}-
+            ${{ runner.os }}-composer-e2e-${{ inputs.php-version }}-
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-progress
+        if: inputs.setup-script == ''
+        env:
+          TYPO3_VERSION: ${{ matrix.typo3 }}
+          TYPO3_PACKAGES: ${{ inputs.typo3-packages }}
+        run: |
+          # If a TYPO3 version constraint is specified for this matrix
+          # entry, override the consumer's composer.json constraints
+          # for the listed packages before installing.
+          if [[ -n "$TYPO3_VERSION" ]]; then
+            PACKAGES=$(echo "$TYPO3_PACKAGES" | jq -r '.[]') || {
+              echo "::error::Failed to parse typo3-packages input: $TYPO3_PACKAGES"
+              exit 1
+            }
+            for pkg in $PACKAGES; do
+              echo "Bumping ${pkg} to ${TYPO3_VERSION} for this matrix entry"
+              composer require --no-update --no-interaction "${pkg}:${TYPO3_VERSION}"
+            done
+          fi
+          composer install --prefer-dist --no-progress
 
       - name: Ensure typo3/cms-install is available
+        if: inputs.setup-script == ''
         # `bin/typo3 setup` (used by the next step) is provided by
         # typo3/cms-install. Many extensions don't declare it as a dev
         # dependency, so install it on-demand if missing. Match the major
@@ -122,6 +228,7 @@ jobs:
             "typo3/cms-install:^${MAJOR}.0"
 
       - name: Setup TYPO3
+        if: inputs.setup-script == ''
         run: |
           # Wait for database
           DB_READY=false
@@ -204,6 +311,7 @@ jobs:
           .Build/bin/typo3 cache:flush
 
       - name: Detect npm lock file
+        if: inputs.setup-script == ''
         id: npm-lockfile
         # TYPO3 extensions frequently gitignore package-lock.json, but
         # actions/setup-node with cache='npm' and `npm ci` both require it.
@@ -217,19 +325,20 @@ jobs:
           fi
 
       - name: Setup Node.js (with npm cache)
-        if: steps.npm-lockfile.outputs.present == 'true'
+        if: inputs.setup-script == '' && steps.npm-lockfile.outputs.present == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
 
       - name: Setup Node.js (no cache)
-        if: steps.npm-lockfile.outputs.present != 'true'
+        if: inputs.setup-script == '' && steps.npm-lockfile.outputs.present != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Install npm dependencies
+        if: inputs.setup-script == ''
         run: |
           if [[ "${{ steps.npm-lockfile.outputs.present }}" == "true" ]]; then
             npm ci
@@ -238,9 +347,13 @@ jobs:
           fi
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps ${{ inputs.playwright-browser }}
+        if: inputs.setup-script == ''
+        env:
+          BROWSER: ${{ inputs.playwright-browser }}
+        run: npx playwright install --with-deps "$BROWSER"
 
       - name: Start PHP server
+        if: inputs.setup-script == ''
         env:
           WEB_DIR: ${{ inputs.web-dir }}
         run: |
@@ -274,28 +387,51 @@ jobs:
           fi
 
       - name: Run E2E tests
+        if: inputs.setup-script == ''
         env:
           TYPO3_BASE_URL: http://localhost:8080
-        run: ${{ inputs.test-command }}
+          E2E_VARIANT: ${{ matrix.variant }}
+          E2E_TYPO3_VERSION: ${{ matrix.typo3 }}
+          TEST_COMMAND: ${{ inputs.test-command }}
+        run: bash -c "$TEST_COMMAND"
 
+      # ─── Common: artifact upload (both modes) ──────────────────────
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: playwright-report
+          # Disambiguate artifact name across matrix entries to avoid
+          # GitHub's "artifact already exists" error for multi-variant runs.
+          name: >-
+            playwright-report${{
+              (matrix.typo3 != '' || matrix.variant != '')
+                && format('-{0}{1}{2}',
+                          matrix.typo3,
+                          (matrix.typo3 != '' && matrix.variant != '') && '-' || '',
+                          matrix.variant)
+              || ''
+            }}
           path: ${{ inputs.artifact-path }}
           retention-days: 7
 
       - name: Upload PHP server logs
+        if: inputs.setup-script == '' && failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: failure()
         with:
-          name: php-server-logs
+          name: >-
+            php-server-logs${{
+              (matrix.typo3 != '' || matrix.variant != '')
+                && format('-{0}{1}{2}',
+                          matrix.typo3,
+                          (matrix.typo3 != '' && matrix.variant != '') && '-' || '',
+                          matrix.variant)
+              || ''
+            }}
           path: /tmp/php-server.log
           retention-days: 3
 
       - name: Stop PHP server
-        if: always()
+        if: inputs.setup-script == '' && always()
         run: |
           if [ -f /tmp/php-server.pid ]; then
             kill "$(cat /tmp/php-server.pid)" 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -348,6 +348,29 @@ jobs:
 | `timeout-minutes` | number | `30` | Job timeout in minutes |
 | `artifact-path` | string | `Tests/E2E/Playwright/reports/` | Path to Playwright reports |
 | `web-dir` | string | `.Build/Web` | TYPO3 web directory (document root) |
+| `typo3-versions` | string (JSON) | `'[""]'` | Matrix dimension: TYPO3 core version constraints (e.g. `'["^13.4.21","^14.3"]'`). Empty entry = use composer.json as-is. Each entry runs as a separate job. |
+| `typo3-packages` | string (JSON) | `'["typo3/cms-core"]'` | Packages to bump per `typo3-versions` entry. |
+| `setup-variants` | string (JSON) | `'[""]'` | Matrix dimension: setup variant names (e.g. `'["bootstrap","core-only","fsc-set"]'`). Passed to `setup-script` and tests as `$E2E_VARIANT`. |
+| `setup-script` | string | `''` | Path to a custom setup script (relative to repo root). When set, replaces the entire built-in pipeline — the script must install deps, set up TYPO3, start any servers, and run tests. Receives `E2E_VARIANT`, `E2E_TYPO3_VERSION`, `E2E_TYPO3_PACKAGES` as env vars. Use this for extensions with comprehensive containerized setups (Apache+PHP-FPM, custom DB seeding, Content Blocks fixtures). |
+
+### Matrix expansion across setup variants
+
+Many TYPO3 extensions need to be tested against several "extension neighborhoods" to catch regressions that are only visible in specific configurations — e.g. a vanilla TYPO3 install with no `fluid_styled_content` site set behaves differently than one with Bootstrap Package, and bugs that show up in one setup are silently masked in the other. Use `typo3-versions` × `setup-variants` to fan out:
+
+```yaml
+jobs:
+  e2e:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main
+    permissions:
+      contents: read
+    with:
+      typo3-versions: '["^13.4.21","^14.3"]'
+      setup-variants: '["bootstrap","core-only","fsc-set"]'
+      setup-script: 'Build/Scripts/runTests.sh'   # script reads $E2E_VARIANT and $E2E_TYPO3_VERSION
+      artifact-path: 'Build/test-results/'
+```
+
+This produces 6 jobs (2 TYPO3 versions × 3 variants), each isolated. The setup script branches on `$E2E_VARIANT` to install the right neighborhood (e.g. with/without `bk2k/bootstrap-package`, with/without `typo3/cms-fluid-styled-content`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ jobs:
 | `artifact-path` | string | `Tests/E2E/Playwright/reports/` | Path to Playwright reports |
 | `web-dir` | string | `.Build/Web` | TYPO3 web directory (document root) |
 | `typo3-versions` | string (JSON) | `'[""]'` | Matrix dimension: TYPO3 core version constraints (e.g. `'["^13.4.21","^14.3"]'`). Empty entry = use composer.json as-is. Each entry runs as a separate job. |
-| `typo3-packages` | string (JSON) | `'["typo3/cms-core"]'` | Packages to bump per `typo3-versions` entry. |
+| `typo3-packages` | string (JSON) | `'["typo3/cms-core"]'` | Packages whose constraints get bumped per `typo3-versions` matrix entry, applied via `composer require --no-update` (or `composer require --with-all-dependencies` when a `composer.lock` is committed) before install. |
 | `setup-variants` | string (JSON) | `'[""]'` | Matrix dimension: setup variant names (e.g. `'["bootstrap","core-only","fsc-set"]'`). Passed to `setup-script` and tests as `$E2E_VARIANT`. |
 | `setup-script` | string | `''` | Path to a custom setup script (relative to repo root). When set, replaces the entire built-in pipeline — the script must install deps, set up TYPO3, start any servers, and run tests. Receives `E2E_VARIANT`, `E2E_TYPO3_VERSION`, `E2E_TYPO3_PACKAGES` as env vars. Use this for extensions with comprehensive containerized setups (Apache+PHP-FPM, custom DB seeding, Content Blocks fixtures). |
 
@@ -366,7 +366,7 @@ jobs:
     with:
       typo3-versions: '["^13.4.21","^14.3"]'
       setup-variants: '["bootstrap","core-only","fsc-set"]'
-      setup-script: 'Build/Scripts/runTests.sh'   # script reads $E2E_VARIANT and $E2E_TYPO3_VERSION
+      setup-script: 'Build/Scripts/runTests.sh'   # reads $E2E_VARIANT, $E2E_TYPO3_VERSION, $E2E_TYPO3_PACKAGES
       artifact-path: 'Build/test-results/'
 ```
 


### PR DESCRIPTION
## Summary

Adds three optional inputs to the reusable E2E workflow so consumers can fan their pipeline across multiple TYPO3 versions × setup variants in a single workflow call, and so extensions with comprehensive containerized setups can plug in their own setup script.

| Input | What |
|---|---|
| `typo3-versions` | JSON array of core constraints; each entry runs as a separate matrix job. Bumps `typo3-packages` (default `[\"typo3/cms-core\"]`) via `composer require --no-update` before install. Empty entry = use composer.json as-is. |
| `setup-variants` | JSON array of variant names exposed to scripts/tests as `$E2E_VARIANT`. Lets consumers test under different sitepackage / FSC / Bootstrap-Package combinations. |
| `setup-script` | Path to a custom script that replaces the entire built-in pipeline. The script gets `E2E_VARIANT`, `E2E_TYPO3_VERSION`, `E2E_TYPO3_PACKAGES` as env vars and is responsible for installing deps, setting up TYPO3, starting servers, and running tests. |

All defaults preserve current single-job behavior. Existing consumers (e.g. `t3x-nr-llm`) keep working untouched: `'[\"\"]'` defaults expand to a 1×1 matrix, and `if: inputs.setup-script == ''` gates short-circuit so the built-in pipeline is unaffected.

## Why

Driven by [netresearch/t3x-rte_ckeditor_image#790](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/790): a regression in a vanilla TYPO3 install (no Bootstrap Package, no `fluid_styled_content` site set) went unnoticed because that extension's only E2E variant loads Bootstrap Package, which configures `lib.parseFunc_RTE` itself and masks the bug. Variant coverage is the right primitive for that bug class, and the pattern applies generally — fresh-install evaluators are an invisible cohort across all our TYPO3 extensions.

## Multi-variant caller example

```yaml
jobs:
  e2e:
    uses: netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main
    permissions:
      contents: read
    with:
      typo3-versions: '[\"^13.4.21\",\"^14.3\"]'
      setup-variants: '[\"bootstrap\",\"core-only\",\"fsc-set\"]'
      setup-script: 'Build/Scripts/runTests.sh'
      artifact-path: 'Build/test-results/'
```

→ 6 jobs (2 TYPO3 × 3 variants), each isolated, artifact names disambiguated automatically.

## Test plan

- [x] YAML syntax validates (`python3 -c \"import yaml; yaml.safe_load(...)\"`)
- [x] Backward compat: existing single-job consumers unchanged when new inputs omitted (defaults `'[\"\"]'` and `''` cover all current callers)
- [ ] Smoke-test from `t3x-nr-llm` (existing simple consumer, no changes needed)
- [ ] Multi-variant smoke from `t3x-rte_ckeditor_image` (PR will follow targeting `@feat/e2e-setup-variants`)

## Follow-up

Once green, downstream PR in `t3x-rte_ckeditor_image` adds `runTests.sh -x VARIANT` flag and wires this workflow with `["bootstrap","core-only","fsc-set"]` to address [#790](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/790) and surface sibling vanilla-install regressions.