### PR TITLE
fix(rector): ship phpstan-rector.neon, stop loading project phpstan

### DIFF
--- a/config/phpstan/phpstan-rector.neon
+++ b/config/phpstan/phpstan-rector.neon
@@ -1,0 +1,32 @@
+# Rector-only PHPStan config for Netresearch TYPO3 extensions.
+#
+# Why a separate file: Rector loads the project's PHPStan config through
+# its bundled phpstan.phar — which does not have ergebnis/phpstan-rules
+# registered, because phpstan/extension-installer only writes its
+# GeneratedConfig.php into the project's vendor/, not into the Rector phar.
+# As a result, the `parameters: ergebnis: { ... }` block in the regular
+# shared phpstan.neon trips a Nette\Schema\ValidationException
+# ("Unexpected item 'parameters › ergebnis'") when Rector loads it.
+#
+# This file mirrors the type-inference bits Rector actually needs (level,
+# treatPhpDocTypesAsCertain, excludePaths) and skips the ergebnis schema
+# entirely. The shared config/rector/rector.php points
+# `$rectorConfig->phpstanConfig()` here by default.
+#
+# Extensions normally do NOT need to include this file directly — they
+# inherit it through the shared rector.php. If an extension wants to
+# tighten Rector's type inference further, it can add its own neon and
+# call `$rectorConfig->phpstanConfig()` explicitly (which appends).
+
+parameters:
+    level: 10
+
+    treatPhpDocTypesAsCertain: false
+    inferPrivatePropertyTypeFromConstructor: true
+
+    excludePaths:
+        - %currentWorkingDirectory%/.Build/*
+        - %currentWorkingDirectory%/ext_emconf.php
+
+    bootstrapFiles:
+        - %currentWorkingDirectory%/.Build/vendor/netresearch/typo3-ci-workflows/config/phpstan/stubs/phpunit-attributes.php

--- a/config/rector/rector.php
+++ b/config/rector/rector.php
@@ -67,7 +67,20 @@ return static function (RectorConfig $rectorConfig, string $projectRoot = ''): v
         $rectorConfig->paths($paths);
 
         $rectorConfig->skip([$projectRoot . '/ext_emconf.php']);
-        $rectorConfig->phpstanConfig($projectRoot . '/Build/phpstan.neon');
+
+        // Point Rector at the dedicated phpstan-rector.neon shipped in
+        // this package — NOT the project's Build/phpstan.neon. Rector
+        // loads its phpstan config through its bundled phpstan.phar,
+        // which does not have ergebnis/phpstan-rules registered, so the
+        // `parameters: ergebnis: { ... }` block in the regular shared
+        // neon trips Nette\Schema\ValidationException
+        // ("Unexpected item 'parameters › ergebnis'"). The Rector-only
+        // neon has the same level/exclude bits Rector needs but skips
+        // the ergebnis schema entirely.
+        $rectorConfig->phpstanConfig(
+            __DIR__ . '/../phpstan/phpstan-rector.neon',
+        );
+
         $rectorConfig->phpVersion(80200);
     }
 


### PR DESCRIPTION
Closes #77.

## Problem

Rector loads the project's PHPStan config through its **bundled** `phpstan.phar`, NOT the project's vendored phpstan binary. The bundled phar does not have `ergebnis/phpstan-rules` registered (`phpstan/extension-installer` writes its `GeneratedConfig.php` into the project's `vendor/`, not the phar), so the `parameters: ergebnis: { allRules: false, ... }` block in `config/phpstan/phpstan.neon` trips:

```
PHP Fatal error: Uncaught _PHPStan_xxx\Nette\Schema\ValidationException:
Unexpected item 'parameters › ergebnis'.
in phar://.../phpstan.phar/vendor/nette/schema/src/Schema/Processor.php:75
```

Every consuming extension currently goes red on `ci / Rector` after adopting v1.3+. The regular `ci / PHPStan` job is fine because the project's vendored phpstan does have ergebnis registered.

## Fix (Option A from #77)

Ship a dedicated `config/phpstan/phpstan-rector.neon` with just the type-inference bits Rector actually needs:
- `level`
- `treatPhpDocTypesAsCertain`
- `inferPrivatePropertyTypeFromConstructor`
- `excludePaths`
- `bootstrapFiles`

…and no ergebnis include. The shared `config/rector/rector.php` now points `$rectorConfig->phpstanConfig()` at this new file by default, replacing the previous `$projectRoot . '/Build/phpstan.neon'`.

## Why this fix and not B/C

- **B (split ergebnis into a separate include)** — adds a moving piece downstream consumers have to know about.
- **C (gate the ergebnis block)** — would need a stub or a parameter check; less clean and harder to maintain.
- **A** — same surface area downstream (`$configure($rectorConfig, __DIR__ . '/..')` still does the right thing), no per-repo workaround needed, the package already proves it can ship multiple phpstan profiles via `includes-no-extension-installer.neon`.

## No downstream changes required

After this lands and downstream extensions widen their constraint to a version including this fix, every `Build/rector.php` continues to work unchanged. The per-repo workaround landed in [`netresearch/t3x-rte_ckeditor_image#793`](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/793) can be reverted in a follow-up.

## Test

`php -l config/rector/rector.php` clean. End-to-end verified against rte_ckeditor_image: `vendor/bin/rector process` runs to completion without the ValidationException.