### PR TITLE
fix(e2e): always compute artifact suffix even when tests fail

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -432,8 +432,17 @@ jobs:
       # like "^14.3" contain `^` which is technically allowed but
       # awkward. We strip everything outside [A-Za-z0-9._-] to keep
       # artifact names predictable and grep-friendly.
+      #
+      # `if: always()` is essential — without it, this step is skipped
+      # when a prior test/setup step exits non-zero, and the suffix
+      # consumed by Upload test results (also `if: always()`) becomes
+      # the empty string. Multiple matrix entries then collide on the
+      # base artifact name "playwright-report" and only one upload
+      # survives. We specifically need the suffix when things are
+      # failing, so the step must always run.
       - name: Compute artifact suffix
         id: artifact-suffix
+        if: always()
         env:
           MATRIX_TYPO3: ${{ matrix.typo3 }}
           MATRIX_VARIANT: ${{ matrix.variant }}


### PR DESCRIPTION
## Summary

`Compute artifact suffix` had no `if:` condition, so when a prior step exited non-zero (e.g. failing tests in scripted-mode `setup-script`, or a failing `Run E2E tests` step in default mode), the step was skipped. The downstream `Upload test results` step is `if: always()`, so it ran anyway and read `steps.artifact-suffix.outputs.value` as the empty string — producing the bare artifact name `playwright-report` for every matrix entry. Multiple variants then collide on that name and only the first upload wins; reports for the rest are lost.

The point of the suffix is to disambiguate **failure** artifacts across matrix entries, which is exactly the case where the suffix step would itself be skipped without `if: always()`. One-line fix plus a comment explaining the trap.

## How it surfaced

[netresearch/t3x-rte_ckeditor_image#794](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/794) wired up a 6-variant E2E matrix (TYPO3 `^13.4.21`/`^14.3` × `{fsc,core-only,bootstrap}`). All 6 hit the same pre-existing latent spec failure, and only one `playwright-report` artifact was retrievable instead of six. The matrix-disambiguation logic added in [#76](https://github.com/netresearch/typo3-ci-workflows/pull/76) was correct in shape but the step ordering let it short-circuit on failure.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes
- [ ] Re-run `t3x-rte_ckeditor_image#794` against `@main` after merge — verify all 6 artifacts upload distinctly: `playwright-report-13.4.21-fsc`, `-13.4.21-core-only`, `-13.4.21-bootstrap`, `-14.3-fsc`, `-14.3-core-only`, `-14.3-bootstrap`

## No behavior change for existing simple consumers

Single-matrix-entry consumers (matrix.typo3 = `""` and matrix.variant = `""`) compute an empty suffix per design and upload as plain `playwright-report` — same as before this PR.