### PR TITLE
feat(preflight): skip duplicate post-merge push runs

### DIFF
--- a/.github/actions/preflight-gate/action.yml
+++ b/.github/actions/preflight-gate/action.yml
@@ -1,9 +1,10 @@
 name: Preflight Gate
 description: >-
   Decide whether the calling reusable workflow should execute on this event.
-  Returns "true" for everything except `push` to a branch where the same SHA
-  has already been validated by a successful `merge_group` run — the post-merge
-  push run is then a known duplicate and is skipped to save compute.
+  Returns "true" for everything except a `push` to the default branch where
+  the **same workflow file** already produced a successful `merge_group` run
+  on the same SHA — that post-merge push run is then a known duplicate and is
+  skipped to save compute.
 
 inputs:
   required-event-conclusions:
@@ -18,10 +19,10 @@ outputs:
   run:
     description: >-
       "true" if the calling workflow should execute, "false" if it should
-      skip as a known duplicate. Always "true" for non-push events. Failure
-      to query the actions API (e.g. missing `actions: read` permission) is
-      treated as "true" — the gate fails open so a misconfigured consumer
-      still gets CI coverage.
+      skip as a known duplicate. Always "true" for non-push events, pushes
+      to non-default branches, and any case where the actions API call
+      fails (missing `actions: read` permission, transient error). The gate
+      fails open so a misconfigured consumer still gets CI coverage.
     value: ${{ steps.gate.outputs.run }}
 
 runs:
@@ -34,6 +35,9 @@ runs:
         REPO: ${{ github.repository }}
         EVENT: ${{ github.event_name }}
         SHA: ${{ github.sha }}
+        REF_NAME: ${{ github.ref_name }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        WORKFLOW_REF: ${{ github.workflow_ref }}
         ALLOWED_CONCLUSIONS: ${{ inputs.required-event-conclusions }}
       run: |
         set -euo pipefail
@@ -45,39 +49,50 @@ runs:
           exit 0
         fi
 
-        # On push: skip only if a successful merge_group run for this exact SHA
-        # exists. That proves the merge queue already validated this tree.
-        # Repos without a merge queue, admin-bypass pushes, and direct pushes
-        # to non-default branches all produce no merge_group run → CI runs.
-        # API failure (missing permission, transient error) → fail open.
-        list_url="repos/${REPO}/actions/runs?head_sha=${SHA}&event=merge_group&per_page=20"
+        # Push to a non-default branch: merge_group lands on the default branch
+        # only, so a same-SHA push elsewhere (e.g. fast-forwarded release branch)
+        # is a separate context that should still run CI.
+        if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::preflight: push to non-default branch ($REF_NAME) — running."
+          exit 0
+        fi
+
+        # Extract the calling workflow file name (e.g. "ci.yml") from
+        # github.workflow_ref. Format: <owner>/<repo>/<path>@<ref>
+        # — strip the @<ref> suffix, then take everything after the last "/".
+        WORKFLOW_FILE="${WORKFLOW_REF%@*}"
+        WORKFLOW_FILE="${WORKFLOW_FILE##*/}"
+        if [ -z "$WORKFLOW_FILE" ]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "::warning::preflight: could not derive workflow file from \$WORKFLOW_REF — running (fail open)."
+          exit 0
+        fi
+
+        # Scope the lookup to *this* workflow file only — a different workflow
+        # succeeding on merge_group for the same SHA does not prove THIS
+        # workflow already ran. per_page=100 is enough headroom for any
+        # realistic re-run history; one page suffices.
+        list_url="repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${SHA}&event=merge_group&per_page=100"
         runs_json=$(gh api "$list_url" 2>/dev/null || echo '{"workflow_runs":[]}')
 
-        # Build a jq filter from the allow-list of conclusions.
-        # Default ("success") gives: select(.conclusion == "success")
-        IFS=',' read -ra allowed <<<"$ALLOWED_CONCLUSIONS"
-        jq_select=""
-        for c in "${allowed[@]}"; do
-          c_trim=$(echo "$c" | tr -d '[:space:]')
-          [ -z "$c_trim" ] && continue
-          if [ -z "$jq_select" ]; then
-            jq_select=".conclusion == \"$c_trim\""
-          else
-            jq_select="$jq_select or .conclusion == \"$c_trim\""
-          fi
-        done
-        [ -z "$jq_select" ] && jq_select='.conclusion == "success"'
-
-        matched=$(echo "$runs_json" \
-          | jq "[.workflow_runs[] | select($jq_select)] | length" 2>/dev/null \
-          || echo 0)
+        # Filter inside jq using --arg so the conclusion list never has to be
+        # spliced into a jq expression as raw shell text.
+        matched=$(echo "$runs_json" | jq \
+          --arg allowed "$ALLOWED_CONCLUSIONS" \
+          '[
+             ($allowed | split(",") | map(gsub("\\s+"; "")) | map(select(length > 0))) as $allow
+             | .workflow_runs[]
+             | select(.conclusion as $c | $allow | index($c))
+           ] | length' \
+          2>/dev/null || echo 0)
         # Paranoia: clamp to integer.
         [[ "$matched" =~ ^[0-9]+$ ]] || matched=0
 
         if [ "$matched" -gt 0 ]; then
           echo "run=false" >> "$GITHUB_OUTPUT"
-          echo "::notice::preflight: skipping push run — $matched merge_group run(s) on SHA $SHA already validated this tree."
+          echo "::notice::preflight: skipping push run — workflow $WORKFLOW_FILE has $matched merge_group run(s) on SHA $SHA already validating this tree."
         else
           echo "run=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::preflight: running — no qualifying merge_group run found for SHA $SHA (event=$EVENT)."
+          echo "::notice::preflight: running — no qualifying merge_group run for workflow $WORKFLOW_FILE on SHA $SHA."
         fi

--- a/.github/actions/preflight-gate/action.yml
+++ b/.github/actions/preflight-gate/action.yml
@@ -1,0 +1,83 @@
+name: Preflight Gate
+description: >-
+  Decide whether the calling reusable workflow should execute on this event.
+  Returns "true" for everything except `push` to a branch where the same SHA
+  has already been validated by a successful `merge_group` run — the post-merge
+  push run is then a known duplicate and is skipped to save compute.
+
+inputs:
+  required-event-conclusions:
+    description: >-
+      Comma-separated list of `merge_group` run conclusions that count as
+      "already validated". Default is "success" only — change to e.g.
+      "success,neutral" if the calling repo's quality gate accepts neutral.
+    required: false
+    default: success
+
+outputs:
+  run:
+    description: >-
+      "true" if the calling workflow should execute, "false" if it should
+      skip as a known duplicate. Always "true" for non-push events. Failure
+      to query the actions API (e.g. missing `actions: read` permission) is
+      treated as "true" — the gate fails open so a misconfigured consumer
+      still gets CI coverage.
+    value: ${{ steps.gate.outputs.run }}
+
+runs:
+  using: composite
+  steps:
+    - id: gate
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        EVENT: ${{ github.event_name }}
+        SHA: ${{ github.sha }}
+        ALLOWED_CONCLUSIONS: ${{ inputs.required-event-conclusions }}
+      run: |
+        set -euo pipefail
+
+        # Non-push events: never the duplicate case — always run.
+        if [ "$EVENT" != "push" ]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::preflight: event=$EVENT — running."
+          exit 0
+        fi
+
+        # On push: skip only if a successful merge_group run for this exact SHA
+        # exists. That proves the merge queue already validated this tree.
+        # Repos without a merge queue, admin-bypass pushes, and direct pushes
+        # to non-default branches all produce no merge_group run → CI runs.
+        # API failure (missing permission, transient error) → fail open.
+        list_url="repos/${REPO}/actions/runs?head_sha=${SHA}&event=merge_group&per_page=20"
+        runs_json=$(gh api "$list_url" 2>/dev/null || echo '{"workflow_runs":[]}')
+
+        # Build a jq filter from the allow-list of conclusions.
+        # Default ("success") gives: select(.conclusion == "success")
+        IFS=',' read -ra allowed <<<"$ALLOWED_CONCLUSIONS"
+        jq_select=""
+        for c in "${allowed[@]}"; do
+          c_trim=$(echo "$c" | tr -d '[:space:]')
+          [ -z "$c_trim" ] && continue
+          if [ -z "$jq_select" ]; then
+            jq_select=".conclusion == \"$c_trim\""
+          else
+            jq_select="$jq_select or .conclusion == \"$c_trim\""
+          fi
+        done
+        [ -z "$jq_select" ] && jq_select='.conclusion == "success"'
+
+        matched=$(echo "$runs_json" \
+          | jq "[.workflow_runs[] | select($jq_select)] | length" 2>/dev/null \
+          || echo 0)
+        # Paranoia: clamp to integer.
+        [[ "$matched" =~ ^[0-9]+$ ]] || matched=0
+
+        if [ "$matched" -gt 0 ]; then
+          echo "run=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::preflight: skipping push run — $matched merge_group run(s) on SHA $SHA already validated this tree."
+        else
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::preflight: running — no qualifying merge_group run found for SHA $SHA (event=$EVENT)."
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,24 @@ on:
 permissions: {}
 
 jobs:
+  preflight:
+    # Skip post-merge `push` runs whose SHA was already validated by a
+    # successful `merge_group` run. See .github/actions/preflight-gate.
+    name: Preflight (event gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      actions: read
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - id: gate
+        uses: netresearch/typo3-ci-workflows/.github/actions/preflight-gate@main
+
   lint:
+    needs: preflight
     name: Lint
-    if: ${{ inputs.run-lint }}
+    if: ${{ inputs.run-lint && needs.preflight.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -181,8 +196,9 @@ jobs:
 
   # CGL runs on first PHP version only - code style results are PHP-version-independent
   cgl:
+    needs: preflight
     name: Code Style
-    if: ${{ inputs.run-cgl }}
+    if: ${{ inputs.run-cgl && needs.preflight.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -241,8 +257,9 @@ jobs:
           fi
 
   phpstan:
+    needs: preflight
     name: PHPStan
-    if: ${{ inputs.run-phpstan }}
+    if: ${{ inputs.run-phpstan && needs.preflight.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -350,8 +367,9 @@ jobs:
 
   # Rector runs on first PHP version only - rule application is PHP-version-independent
   rector:
+    needs: preflight
     name: Rector
-    if: ${{ inputs.run-rector }}
+    if: ${{ inputs.run-rector && needs.preflight.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -404,8 +422,9 @@ jobs:
           fi
 
   unit-tests:
+    needs: preflight
     name: Unit Tests
-    if: ${{ inputs.run-unit-tests }}
+    if: ${{ inputs.run-unit-tests && needs.preflight.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -524,8 +543,9 @@ jobs:
           fail_ci_if_error: false
 
   functional-tests:
+    needs: preflight
     name: Functional Tests
-    if: ${{ inputs.run-functional-tests && inputs.functional-test-db != 'sqlite' }}
+    if: ${{ inputs.run-functional-tests && inputs.functional-test-db != 'sqlite' && needs.preflight.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -664,8 +684,9 @@ jobs:
           fail_ci_if_error: false
 
   functional-tests-sqlite:
+    needs: preflight
     name: Functional Tests SQLite
-    if: ${{ inputs.run-functional-tests && inputs.functional-test-db == 'sqlite' }}
+    if: ${{ inputs.run-functional-tests && inputs.functional-test-db == 'sqlite' && needs.preflight.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,11 @@ jobs:
     outputs:
       run: ${{ steps.gate.outputs.run }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - id: gate
         uses: netresearch/typo3-ci-workflows/.github/actions/preflight-gate@main
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,7 +94,23 @@ on:
 permissions: {}
 
 jobs:
+  preflight:
+    # Skip post-merge `push` runs whose SHA was already validated by a
+    # successful `merge_group` run. See .github/actions/preflight-gate.
+    name: Preflight (event gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      actions: read
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - id: gate
+        uses: netresearch/typo3-ci-workflows/.github/actions/preflight-gate@main
+
   e2e:
+    needs: preflight
+    if: needs.preflight.outputs.run == 'true'
     # Surface the matrix entry in the job name so multi-variant runs are
     # distinguishable in CI logs. Falls back to a plain "E2E" label when
     # neither matrix axis is in use.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,6 +105,11 @@ jobs:
     outputs:
       run: ${{ steps.gate.outputs.run }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - id: gate
         uses: netresearch/typo3-ci-workflows/.github/actions/preflight-gate@main
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -47,11 +47,26 @@ on:
 permissions: {}
 
 jobs:
+  preflight:
+    # Skip post-merge `push` runs whose SHA was already validated by a
+    # successful `merge_group` run. See .github/actions/preflight-gate.
+    name: Preflight (event gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      actions: read
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - id: gate
+        uses: netresearch/typo3-ci-workflows/.github/actions/preflight-gate@main
+
   fuzz-tests:
+    needs: preflight
     name: Fuzz Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: inputs.run-fuzz-tests
+    if: inputs.run-fuzz-tests && needs.preflight.outputs.run == 'true'
     permissions:
       contents: read
     steps:
@@ -93,10 +108,11 @@ jobs:
         run: .Build/bin/phpunit -c "$PHPUNIT_CONFIG" --testsuite "$FUZZ_SUITE" --no-coverage --colors=never
 
   mutation-testing:
+    needs: preflight
     name: Mutation Testing (Infection)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: inputs.run-mutation-tests
+    if: inputs.run-mutation-tests && needs.preflight.outputs.run == 'true'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -58,6 +58,11 @@ jobs:
     outputs:
       run: ${{ steps.gate.outputs.run }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - id: gate
         uses: netresearch/typo3-ci-workflows/.github/actions/preflight-gate@main
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -17,7 +17,23 @@ on:
 permissions: {}
 
 jobs:
+  preflight:
+    # Skip post-merge `push` runs whose SHA was already validated by a
+    # successful `merge_group` run. See .github/actions/preflight-gate.
+    name: Preflight (event gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      actions: read
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - id: gate
+        uses: netresearch/typo3-ci-workflows/.github/actions/preflight-gate@main
+
   php-licenses:
+    needs: preflight
+    if: needs.preflight.outputs.run == 'true'
     name: PHP License Audit
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -28,6 +28,11 @@ jobs:
     outputs:
       run: ${{ steps.gate.outputs.run }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - id: gate
         uses: netresearch/typo3-ci-workflows/.github/actions/preflight-gate@main
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,6 +38,11 @@ jobs:
     outputs:
       run: ${{ steps.gate.outputs.run }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - id: gate
         uses: netresearch/typo3-ci-workflows/.github/actions/preflight-gate@main
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,11 +27,26 @@ on:
 permissions: {}
 
 jobs:
+  preflight:
+    # Skip post-merge `push` runs whose SHA was already validated by a
+    # successful `merge_group` run. See .github/actions/preflight-gate.
+    name: Preflight (event gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      actions: read
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - id: gate
+        uses: netresearch/typo3-ci-workflows/.github/actions/preflight-gate@main
+
   composer-audit:
+    needs: preflight
     name: Composer Audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ !inputs.skip-composer-audit }}
+    if: ${{ !inputs.skip-composer-audit && needs.preflight.outputs.run == 'true' }}
     permissions:
       contents: read
     steps:
@@ -74,10 +89,11 @@ jobs:
         run: composer audit --format=plain --abandoned=report
 
   opengrep:
+    needs: preflight
     name: SAST (Opengrep)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: ${{ !inputs.skip-opengrep }}
+    if: ${{ !inputs.skip-opengrep && needs.preflight.outputs.run == 'true' }}
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## Summary

Every queued merge runs full CI twice on the same SHA: once on `merge_group` (gates the queue) and again on `push` when the validated commit lands on the default branch. The post-merge `push` run is pure duplicate work — same SHA, same tree, same outcome.

This adds a `preflight` composite action that decides whether the calling reusable should execute, and wires it into all five gating reusables — `ci`, `e2e`, `security`, `fuzz`, `license-check`.

## How it works

- **Non-push events**: `run=true`. Always execute. (PR, merge_group, schedule, workflow_dispatch.)
- **Push events**: query `actions/runs?head_sha=<sha>&event=merge_group` and look for a successful run on the same SHA.
  - Found → `run=false`. The merge queue already validated this tree.
  - Not found → `run=true`. No proof of prior validation; run CI.

This is a direct fact-test, not a configuration heuristic. It correctly handles:

| Scenario | Has merge_group run for SHA? | Result |
|---|---|---|
| Repo with merge_queue, normal merge | yes | push run skips ✓ |
| Repo without merge_queue | no (event never fired) | push run runs ✓ |
| Admin bypass on protected repo | no (queue circumvented) | push run runs ✓ |
| Push to non-default branch | no | push run runs ✓ |

## Failure mode

API failure (missing `actions: read`, transient error) → fail open (`run=true`). Misconfigured consumers still get CI coverage; they just don't get the dedup benefit.

## Required consumer change

For repos that want the dedup, the calling job needs `actions: read`:

```yaml
ci:
  uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
  permissions:
    contents: read
    actions: read   # new — required for the preflight gate's API call
  ...
```

Without this, the gate falls open and CI runs exactly as before. Adoption is opt-in.

## Trade-offs / things to know

1. **Adds ~5–15s startup latency to every CI run** (the preflight job's queue + run time). Even on PR / merge_group / schedule where it always returns `run=true`. Acceptable price for the dedup; flagging it.
2. **`@main` reference in the workflow → composite action** is a version-coupling footgun once we tag a release. Workflow at tag `v1.x` would reference action at `@main`. Fine for an initial main-only rollout; before the next tagged release, decide on a pinning strategy (Renovate-bumped SHA vs major-version float). Tracked as a follow-up.
3. **Required-status-check names**: existing checks now report as `Skipped` on `push` to default branch. `Skipped` is treated as a passing required check. Consumers' rulesets that gate on PR / merge_group are unaffected. No ruleset changes needed.
4. **The Q2 path-filter for E2E doc-only PRs is intentionally not included.** That needs measurement first (is E2E in the merge_group required-checks list? then PR-time skip saves wait, not compute), and a conservative path allow-list. Separate follow-up.

## Verification

- `actionlint` and `yamllint` clean on all five workflow files and the composite action.
- The jq pipeline (`gh api ... | jq '[.workflow_runs[] | select(.conclusion=="success")] | length'`) was tested against real data from `netresearch/t3x-rte_ckeditor_image` SHA `49d1cf104e38baa75f39b5d25e5305cd44b144b4` (the merge of #809) — returns `2` successful merge_group runs, matching the expected pre-merge gating runs.
- Composite action's `gh api ... 2>/dev/null || echo '{"workflow_runs":[]}'` fallback verified by clamping non-integer outputs to `0` before comparison.

## Test plan

- [ ] CI on this PR runs the full matrix on `pull_request` (preflight returns `run=true` for non-push events).
- [ ] Merge to `main` via the queue (this repo's `self-ci.yml` is the relevant runner) — observe that the post-merge `push` run reports `Skipped` for the gating jobs.
- [ ] Roll out to consumers by adding `actions: read` to their calling jobs (separate per-consumer PRs; can be batched).

## Follow-ups (separate PRs, not blocking)

- E2E paths-filter for doc-only changes (after measuring merge_group required-checks list).
- Pinning strategy decision before next tagged release.
- Org-wide consumer rollout: add `actions: read` to existing `uses:` calls of these reusables across all TYPO3 extension repos.