### PR TITLE
feat(release): use .sigstore.json extension for cosign signature bundles

### DIFF
--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -210,9 +210,12 @@ jobs:
           for file in *; do
             [ -f "$file" ] || continue
             case "$file" in
-              *.bundle) continue ;;  # don't sign already-generated bundles
+              *.sigstore.json) continue ;;  # don't sign already-generated signature bundles
             esac
-            cosign sign-blob --yes "$file" --bundle "${file}.bundle"
+            # Use .sigstore.json (Sigstore bundle format) so OSSF Scorecard
+            # recognizes the artifact as signed. The bytes are identical to
+            # cosign's --bundle output; only the extension differs.
+            cosign sign-blob --yes "$file" --bundle "${file}.sigstore.json"
           done
 
       - name: Generate build-provenance attestation
@@ -375,7 +378,7 @@ jobs:
 
             ```bash
             cosign verify-blob \
-              --bundle ${{ inputs.archive-prefix }}-${{ needs.build-and-sign.outputs.version }}.zip.bundle \
+              --bundle ${{ inputs.archive-prefix }}-${{ needs.build-and-sign.outputs.version }}.zip.sigstore.json \
               --certificate-identity-regexp "https://github.com/${{ github.repository_owner }}/.*" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               ${{ inputs.archive-prefix }}-${{ needs.build-and-sign.outputs.version }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,13 @@ jobs:
           cd dist
           for file in *; do
             [ -f "$file" ] || continue
-            cosign sign-blob --yes "$file" --bundle "${file}.bundle"
+            case "$file" in
+              *.sigstore.json) continue ;;  # don't sign already-generated signature bundles
+            esac
+            # Use .sigstore.json (Sigstore bundle format) so OSSF Scorecard
+            # recognizes the artifact as signed. The bytes are identical to
+            # cosign's --bundle output; only the extension differs.
+            cosign sign-blob --yes "$file" --bundle "${file}.sigstore.json"
           done
 
       - name: Generate attestation
@@ -157,7 +163,7 @@ jobs:
 
             ```bash
             cosign verify-blob \
-              --bundle ${{ inputs.archive-prefix }}-${{ steps.version.outputs.version }}.zip.bundle \
+              --bundle ${{ inputs.archive-prefix }}-${{ steps.version.outputs.version }}.zip.sigstore.json \
               --certificate-identity-regexp "https://github.com/${{ github.repository_owner }}/.*" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               ${{ inputs.archive-prefix }}-${{ steps.version.outputs.version }}.zip


### PR DESCRIPTION
## Summary

OSSF Scorecard's `Signed-Releases` check doesn't recognize cosign's default `.bundle` extension. Renaming to `.sigstore.json` (same format, different extension) makes our signed releases countable as signed without changing how verification works.

## Why this is needed

Scorecard pattern-matches release assets against this fixed list: `.sig`, `.asc`, `.minisig`, `.sigstore`, `.sigstore.json`, `.intoto.jsonl`. The `.bundle` extension that `cosign sign-blob --bundle` writes by default is **not** on that list. Result on every consumer repo:

```
Warn: release artifact vX.Y.Z not signed
Warn: release artifact vX.Y.Z does not have provenance
```

— even though the artifact **is** signed (cosign bundle on disk) and **does** have provenance (GitHub-native build attestation, but Scorecard can't see those).

The bytes inside cosign's bundle file already are the [Sigstore bundle JSON format](https://docs.sigstore.dev/cosign/verifying/verify/). The rename is purely cosmetic for tooling detection — `cosign verify-blob --bundle file.sigstore.json` works identically.

## Changes

- `.github/workflows/release.yml`: signing loop writes `.sigstore.json` instead of `.bundle`; verify-docs in release notes updated
- `.github/workflows/release-typo3-extension.yml`: same change
- Both workflows: added/aligned skip-pattern so the loop doesn't try to re-sign signature files

## Backwards compatibility

- **Past releases**: cannot be retroactively fixed — GitHub releases are immutable. Old releases keep `.bundle`, new releases get `.sigstore.json`.
- **Verification**: `cosign verify-blob --bundle <file>` accepts both — the `--bundle` flag refers to file format, not file extension. Future verifiers point to `.sigstore.json`; verifiers of past artifacts continue to use `.bundle`.
- **Downstream docs**: Searched all 18 consumer repos. Hand-written cosign verify docs exist only in `t3x-nr-llm/README.md` (which uses a separate Go-app release path, unaffected). All other consumers either use the auto-generated release-notes verify block (now updated) or have no hand-written verify docs.

## Test plan

- [ ] CI passes (workflow validation only — no release executes from a workflow PR)
- [ ] After merge, the next consumer release should produce `.sigstore.json` files visible on the GitHub release page
- [ ] OSSF Scorecard re-scan should change Signed-Releases from `0` to `8/10` for repos that release after the merge (10/10 still requires SLSA `.intoto.jsonl` provenance assets, which is a separate decision)