### PR TITLE
chore(ci): add zizmor config tuned to NR conventions

### DIFF
--- a/.github/workflows/self-ci.yml
+++ b/.github/workflows/self-ci.yml
@@ -216,8 +216,10 @@ jobs:
               # Skip local references (./)
               [[ "$ref" == ./* ]] && continue
 
-              # Skip self-references to this repo's reusable workflows
-              [[ "$ref" == netresearch/typo3-ci-workflows/* ]] && continue
+              # Skip first-party Netresearch reusable workflows: by policy
+              # they track @main and are never SHA-pinned (third-party
+              # actions still require a full SHA pin below).
+              [[ "$ref" == netresearch/* ]] && continue
 
               # Skip docker:// references pinned by digest (@sha256:...)
               [[ "$ref" == docker://*@sha256:* ]] && continue
@@ -238,3 +240,10 @@ jobs:
             echo "Pin actions to full commit SHAs (e.g., uses: actions/checkout@<sha> # v6.0.2)"
             exit 1
           fi
+
+  zizmor:
+    name: zizmor
+    permissions:
+      contents: read
+      security-events: write
+    uses: netresearch/.github/.github/workflows/zizmor.yml@main

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,21 @@
+# zizmor (https://zizmor.sh) configuration
+#
+# Tunes zizmor to Netresearch conventions so the CI gate reports only
+# actionable findings. Third-party actions remain hash-pin enforced.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # First-party reusable workflows track @main by policy and are
+        # never SHA-pinned, so fixes propagate to all consumers.
+        "netresearch/*": ref-pin
+        # Everything else must be pinned to a full commit SHA.
+        "*": hash-pin
+
+  unpinned-images:
+    # The service-container database image is a parametrized caller input
+    # (image: ${{ inputs.db-image }}); a digest cannot be pinned here, the
+    # obligation lives with the calling repository.
+    ignore:
+      - ci.yml
+      - e2e.yml


### PR DESCRIPTION
Adds `.github/zizmor.yml` so the [zizmor](https://zizmor.sh) GitHub Actions audit reports only actionable findings on this repo.

## What

- **`unpinned-uses`**: first-party `netresearch/*` reusable-workflow refs use the `ref-pin` policy — they track `@main` by [standing convention](https://github.com/netresearch) so fixes propagate to consumers. All third-party actions remain `hash-pin` enforced.
- **`unpinned-images`**: ignores the parametrized service-container `image: ${{ inputs.db-image }}` in `ci.yml` and `e2e.yml` — a digest cannot be pinned for a caller-supplied input; that obligation lives with the calling repo.

## Why

A baseline zizmor run reported 8 "high" findings, but **every one** was either a first-party `@main` ref or a parametrized image — i.e. by-design, not a vulnerability. This config removes that noise so a future zizmor CI gate flags real regressions only. No workflow behaviour changes.

Verified locally: `zizmor .github/workflows/` now reports 0 high / 0 medium (3 informational remain).