### PR TITLE
fix(release): stop sbom-action attaching assets in contents:read job

### DIFF
--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -184,6 +184,11 @@ jobs:
           path: .
           format: spdx-json
           output-file: dist/${{ inputs.archive-prefix }}-${{ steps.version.outputs.version }}.sbom.spdx.json
+          # This job is least-privilege (contents: read). The dedicated
+          # "Create GitHub Release" job (contents: write) attaches all assets.
+          # sbom-action defaults to upload-release-assets: true, which fails
+          # here with "Resource not accessible by integration".
+          upload-release-assets: false
 
       - name: Generate SBOM (CycloneDX)
         if: inputs.include-sbom
@@ -192,6 +197,8 @@ jobs:
           path: .
           format: cyclonedx-json
           output-file: dist/${{ inputs.archive-prefix }}-${{ steps.version.outputs.version }}.sbom.cdx.json
+          # See SPDX step above: contents: read job must not attach release assets.
+          upload-release-assets: false
 
       - name: Generate checksums
         run: |


### PR DESCRIPTION
## Problem

Every TYPO3 extension release using `release-typo3-extension.yml` fails at the **Generate SBOM (SPDX)** step with:

```
##[error]Resource not accessible by integration - https://docs.github.com/rest
```

The SBOM is generated fine (syft runs, file is written, workflow artifact uploads). The failure is the *next* thing `anchore/sbom-action` does automatically:

```
--------------------- Attaching SBOMs to release: 'v0.9.2' ---------------------
##[error]Resource not accessible by integration
```

## Root cause

`anchore/sbom-action@v0.24.0` defaults to **`upload-release-assets: true`** (verified in the action's `action.yml` at the pinned SHA). On a tag/release ref it attaches the SBOM to the GitHub release via the REST API — which needs `contents: write`.

But the `Build & sign artifacts` job runs least-privilege with `contents: read` (lines 85-88). → 403.

Release assets are attached by the dedicated **Create GitHub Release** job (`contents: write`, line 302), so the sbom-action upload is both **redundant and a permission violation**.

## Fix

Set `upload-release-assets: false` on both SBOM steps (SPDX + CycloneDX). SBOMs still reach the release via the `release-dist` artifact downloaded by the release job. Keeps the job least-privilege.

## Verification

- `actionlint` — clean
- `zizmor` — no new findings (1 pre-existing informational, unrelated)
- Reproduced by [t3x-nr-passkeys-be v0.9.1](https://github.com/netresearch/t3x-nr-passkeys-be/actions/runs/26588500606/job/78340831401) and [v0.9.2](https://github.com/netresearch/t3x-nr-passkeys-be/actions/runs/26591538680/job/78351330560) release runs — both died at exactly this step.