### PR TITLE
fix(security): retry Opengrep download to survive transient CDN errors

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -180,7 +180,10 @@ jobs:
       - name: Install Opengrep
         run: |
           mkdir -p "$HOME/.local/bin"
-          curl -fsSL -o "$HOME/.local/bin/opengrep" \
+          # Retry to ride out transient GitHub release-CDN errors (e.g. HTTP 504)
+          # that otherwise fail the whole security job on a flaky download.
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+            -o "$HOME/.local/bin/opengrep" \
             "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
           echo "${OPENGREP_SHA256}  $HOME/.local/bin/opengrep" | sha256sum -c -
           chmod +x "$HOME/.local/bin/opengrep"


### PR DESCRIPTION
## Problem

The `Install Opengrep` step in `security.yml` downloads the release binary with a plain `curl -fsSL` and **no retry**. On 2026-06-08 a transient `HTTP 504` from GitHub's release CDN aborted the whole `security / SAST (Opengrep)` job across multiple consumer extensions simultaneously (t3x-nr-textdb, t3x-nr-image-optimize, t3x-nr-image-sitemap, t3x-universal-messenger). The asset was reachable again moments later — purely a flaky download.

## Fix

Add retry/backoff to the download:

```
curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 ...
```

Transient 4xx/5xx and connection errors are now retried instead of failing the build. The pinned version and the sha256 integrity check are unchanged.