### PR TITLE
fix(ci): disable audit block-insecure before composer install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,9 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-cgl-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: |
+          composer config --no-plugins audit.block-insecure false
+          composer install --prefer-dist --no-progress
 
       - name: Run code style check
         env:
@@ -405,6 +407,7 @@ jobs:
           for pkg in $PACKAGES; do
             composer require --no-update "$pkg:${TYPO3_VERSION}"
           done
+          composer config --no-plugins audit.block-insecure false
           composer install --prefer-dist --no-progress
 
       - name: Run PHPStan
@@ -467,7 +470,9 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-rector-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: |
+          composer config --no-plugins audit.block-insecure false
+          composer install --prefer-dist --no-progress
 
       - name: Run Rector
         env:
@@ -570,6 +575,7 @@ jobs:
           for pkg in $PACKAGES; do
             composer require --no-update "$pkg:${TYPO3_VERSION}"
           done
+          composer config --no-plugins audit.block-insecure false
           composer install --prefer-dist --no-progress
 
       - name: Run unit tests
@@ -705,6 +711,7 @@ jobs:
           for pkg in $PACKAGES; do
             composer require --no-update "$pkg:${TYPO3_VERSION}"
           done
+          composer config --no-plugins audit.block-insecure false
           composer install --prefer-dist --no-progress
 
       - name: Run functional tests
@@ -830,6 +837,7 @@ jobs:
           for pkg in $PACKAGES; do
             composer require --no-update "$pkg:${TYPO3_VERSION}"
           done
+          composer config --no-plugins audit.block-insecure false
           composer install --prefer-dist --no-progress
 
       - name: Run functional tests


### PR DESCRIPTION
## Problem

The TYPO3 security release of 2026-06-15 (TYPO3-CORE-SA-2026-007…019)
marks every published `typo3/cms-core` **12.4.x** (up to v12.4.45) as
affected. The fix, **12.4.46**, is ELTS-only and is **not on public
Packagist** (v12.4 free support has ended). Composer 2.8+ blocks
installing advisory-flagged packages when no unaffected version exists,
so every `ci.yml` job testing `^12.4` failed at the install step
(`rector`, `cgl`, `phpstan`, `unit`, `functional`).

`^13.4` / `^14.3` are unaffected because their fixes (13.4.31 / 14.3.3)
*are* on Packagist, so Composer resolves to them automatically.

## Fix

`security.yml` already runs `composer config --no-plugins
audit.block-insecure false` before its install. `ci.yml` did not — that
asymmetry is the bug. This adds the same line before each of the six
`composer install` invocations, so the matrix install resolves the
latest available version as it did before.

This is install-time only; the dedicated `composer audit` job remains
the security gate. For supported versions it is a no-op (the fixed
version is still selected). No advisory-ID list to maintain.
