### PR TITLE
docs(ci): caller-permission contract headers on all reusables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,23 @@ on:
       CODECOV_TOKEN:
         required: false
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     preflight:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
+#       permissions:
+#         contents: read
 permissions: {}
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,23 @@ on:
         type: number
         default: 7
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     render:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/docs.yml@main
+#       permissions:
+#         contents: read
 permissions: {}
 
 env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,6 +91,23 @@ on:
         type: string
         default: ''
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     preflight:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main
+#       permissions:
+#         contents: read
 permissions: {}
 
 jobs:

--- a/.github/workflows/extended-testing.yml
+++ b/.github/workflows/extended-testing.yml
@@ -74,6 +74,23 @@ on:
       INFECTION_DASHBOARD_API_KEY:
         required: false
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     unit-coverage:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/extended-testing.yml@main
+#       permissions:
+#         contents: read
 permissions: {}
 
 jobs:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -44,6 +44,23 @@ on:
         type: number
         default: 60
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     preflight:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
+#       permissions:
+#         contents: read
 permissions: {}
 
 jobs:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -14,6 +14,23 @@ on:
         type: string
         default: '"(SSPL|BSL)"'
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     preflight:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
+#       permissions:
+#         contents: read
 permissions: {}
 
 jobs:

--- a/.github/workflows/publish-to-docs.yml
+++ b/.github/workflows/publish-to-docs.yml
@@ -51,6 +51,23 @@ on:
         type: number
         default: 180
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     verify:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-docs.yml@main
+#       permissions:
+#         contents: read
 permissions: {}
 
 jobs:

--- a/.github/workflows/publish-to-packagist.yml
+++ b/.github/workflows/publish-to-packagist.yml
@@ -29,6 +29,23 @@ on:
         type: number
         default: 15
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     verify:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-packagist.yml@main
+#       permissions:
+#         contents: read
 permissions: {}
 
 jobs:

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -74,6 +74,23 @@ on:
       TYPO3_TER_ACCESS_TOKEN:
         required: true
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     publish:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
+#       permissions:
+#         contents: read
 permissions: {}
 
 jobs:

--- a/.github/workflows/release-typo3-extension.yml
+++ b/.github/workflows/release-typo3-extension.yml
@@ -75,6 +75,25 @@ on:
       TYPO3_TER_ACCESS_TOKEN:
         required: false
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     build-and-sign:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml@main
+#       permissions:
+#         attestations: write
+#         contents: write
+#         id-token: write
 permissions: {}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,25 @@ on:
         type: boolean
         default: true
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     release:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/release.yml@main
+#       permissions:
+#         attestations: write
+#         contents: write
+#         id-token: write
 permissions: {}
 
 jobs:

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -50,6 +50,23 @@ on:
       TYPO3_TER_ACCESS_TOKEN:
         required: false
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     resolve-version:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/republish.yml@main
+#       permissions:
+#         contents: read
 permissions: {}
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,6 +24,24 @@ on:
         type: string
         default: '--config auto --error --severity WARNING'
 
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# the run fails with `startup_failure` before any job executes
+# (GitHub rejects the workflow at startup when the reusable declares
+# a permission the caller did not grant). NOTE: setting ANY scope in a
+# `permissions:` block forces every UNLISTED scope to `none`, and a job
+# that omits `permissions:` inherits the repository default
+# (default_workflow_permissions) — so a repo hardened to `read` will
+# startup-fail here unless these scopes are granted explicitly.
+#
+#   jobs:
+#     preflight:
+#       uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+#       permissions:
+#         contents: read
+#         security-events: write
 permissions: {}
 
 jobs:


### PR DESCRIPTION
Mirrors netresearch/.github#187. Adds a `# CALLER REQUIREMENTS` header to all 13 reusables documenting the exact GITHUB_TOKEN scopes a caller must grant (startup_failure before any job if under-granted; unlisted scopes become none; a calling job with no permissions block inherits the repo default). Highest-value entries: `security.yml` (contents:read + security-events:write) and `release(-typo3-extension).yml` (contents:write + id-token:write + attestations:write). Pure docs, no behaviour change. Central reference: netresearch/.github `docs/reusable-workflow-permissions.md`.