### PR TITLE
fix(ci): pin PHPUnit < 13 for PHPStan job until phpstan-phpunit supports it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,14 @@ jobs:
           for pkg in $PACKAGES; do
             composer require --no-update "$pkg:${TYPO3_VERSION}"
           done
+          # phpstan/phpstan-phpunit (^2.0, currently 2.0.16) does not yet model
+          # PHPUnit 13's mock-builder API, so analyzing test mocks under PHPUnit
+          # 13 produces false "undefined method InvocationStubber::with()" /
+          # "willReturn() on mixed" errors (PHP 8.4/8.5 resolve PHPUnit 13 via
+          # typo3/testing-framework). Pin PHPUnit < 13 for STATIC ANALYSIS ONLY;
+          # the Unit/Functional jobs still run the full PHPUnit matrix. Remove
+          # this cap once phpstan-phpunit supports PHPUnit 13.
+          composer require --dev --no-update "phpunit/phpunit:<13"
           composer config --no-plugins audit.block-insecure false
           composer install --prefer-dist --no-progress
 


### PR DESCRIPTION
## Problem

`phpstan/phpstan-phpunit ^2.0` (currently **2.0.16**) does not model PHPUnit 13's mock-builder API. On PHP 8.4/8.5, composer resolves **PHPUnit 13** transitively via `typo3/testing-framework` (`^9.5` allows `^11 || ^12 || ^13`, with no upper pin on PHPUnit), so static analysis of test mocks emits hundreds of false errors:

```
Call to an undefined method PHPUnit\Framework\MockObject\InvocationStubber::with().
Cannot call method willReturn() on mixed.
```

This silently broke the `PHPStan (8.4)` / `PHPStan (8.5)` matrix cells for **every consumer repo** on fresh dependency resolution (no committed lockfile). The Unit/Functional jobs keep passing on PHPUnit 13 — the tests run fine; only the static mock typing is unmodeled.

First observed breaking `netresearch/t3x-rte_ckeditor_image` [PR #853](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/853): PHPStan 8.4/8.5 green on 2026-06-16, red on 2026-06-18, no code change between.

## Fix

Pin `phpunit/phpunit:<13` in the **PHPStan job's install step only**. The Unit and Functional jobs are untouched and keep running the full PHPUnit matrix (including 13). Static analysis runs under PHPUnit 12, which phpstan-phpunit 2.0.16 models correctly.

Scoped to static analysis because PHPStan does not execute tests — the exact PHPUnit version is irrelevant to analysis correctness, only stub compatibility matters.

## Follow-up

Remove this cap once `phpstan-phpunit` ships PHPUnit 13 support. A `# TODO` comment in the workflow flags it.

https://claude.ai/code/session_015Myeo4imGJGskBMto9BVAm